### PR TITLE
fix: make `pnpm run typecheck` cover every workspace package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,11 +60,12 @@ jobs:
         env:
           DATABASE_URL: postgres://curia:curia_test@localhost:5432/curia_test
 
+      # Covers src/, skills/, tests/ and every workspace package (apps/*, packages/*)
+      # via `pnpm -r run typecheck` — see #1726. There is deliberately no separate
+      # console step: a hand-maintained per-package list here is how apps/console
+      # came to be missing from the root script.
       - name: Type check
         run: pnpm run typecheck
-
-      - name: Type check console
-        run: pnpm --filter @curia/console run typecheck
 
       - name: Build console
         run: pnpm --filter @curia/console run build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,8 +59,12 @@ caveats; standard commands live in `package.json` scripts and `scripts/setup.sh`
   to mark identity configured, then restart the backend yourself.
 
 ### Lint / typecheck / test / build (commands in `package.json`)
-- Lint: `pnpm run lint`. Typecheck: `pnpm run typecheck` (3 tsconfigs) and
-  `pnpm --filter @curia/console run typecheck`. Build console: `pnpm --filter @curia/console run build`.
+- Lint: `pnpm run lint`. Typecheck: `pnpm run typecheck` — 3 root tsconfigs (`src/`,
+  `skills/`, `tests/`) plus **every** workspace package under `apps/*` and `packages/*`
+  via `pnpm -r run typecheck`. No workspace package is checked separately; a per-package
+  list here is how `apps/console` came to be missed (#1726). Not covered: `scripts/**`
+  (#1729) and `apps/*/vite.config.ts`. Build console:
+  `pnpm --filter @curia/console run build`.
 - Tests: `pnpm test` (vitest). Integration tests **require `DATABASE_URL`** and applied
   migrations; they `describe.skip` when it is unset. Mirror CI by using a separate
   `curia_test` DB: create it, migrate it, then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
-- **Root `typecheck` coverage** — the script enumerated packages by hand and skipped `apps/console`, reporting success over real errors; it now runs `pnpm -r run typecheck`, and a guard test fails if a workspace package would be silently skipped. (#1726)
+- **Root `typecheck` coverage** — now recurses over every workspace package; `apps/console` was silently skipped. (#1726)
 - **`docker-publish` `:latest`** — pinned `flavor: latest=false`; a dispatched re-publish no longer moves `latest` backwards. (#1718)
 - **`docker-publish` re-publish** — the ref-dropdown form now resolves and validates its tag like the input form. (#1718)
 - **`docker-publish` dispatch** — a dispatch that would publish nothing, or name a tag from an unrelated branch, is refused. (#1718)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **Root `typecheck` coverage** — the script enumerated packages by hand and skipped `apps/console`, reporting success over real errors; it now runs `pnpm -r run typecheck`, and a guard test fails if a workspace package would be silently skipped. (#1726)
 - **`docker-publish` `:latest`** — pinned `flavor: latest=false`; a dispatched re-publish no longer moves `latest` backwards. (#1718)
 - **`docker-publish` re-publish** — the ref-dropdown form now resolves and validates its tag like the input form. (#1718)
 - **`docker-publish` dispatch** — a dispatch that would publish nothing, or name a tag from an unrelated branch, is refused. (#1718)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,9 +27,20 @@ Cross-cutting: Audit Logger, Memory Engine, Scheduler.
 
 ### Type Checking
 
-Always run `pnpm --prefix <worktree> run typecheck` (not raw `tsc --noEmit`) —
+Always run `pnpm -C <worktree> run typecheck` (not raw `tsc --noEmit`) —
 CI uses `pnpm run typecheck` which may resolve a different tsconfig chain than
 a bare `tsc` invocation. Run this before every commit that touches `.ts` files.
+
+This one command is complete: it covers `src/`, `skills/` and `tests/` (three
+tsconfig projects) plus every workspace package under `apps/*` and `packages/*`
+via `pnpm -r run typecheck`. Nothing needs to be checked separately, and new
+workspace packages are picked up automatically — they only need their own
+`typecheck` script, which `tests/unit/workspace-typecheck-coverage.test.ts`
+enforces.
+
+Use `-C`, not `--prefix`: for pnpm (unlike npm) `--prefix` sets only the install
+location, so workspace resolution still comes from the process CWD and can
+resolve the wrong workspace entirely.
 
 ### Strict TypeScript Patterns
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,12 +31,21 @@ Always run `pnpm -C <worktree> run typecheck` (not raw `tsc --noEmit`) —
 CI uses `pnpm run typecheck` which may resolve a different tsconfig chain than
 a bare `tsc` invocation. Run this before every commit that touches `.ts` files.
 
-This one command is complete: it covers `src/`, `skills/` and `tests/` (three
-tsconfig projects) plus every workspace package under `apps/*` and `packages/*`
-via `pnpm -r run typecheck`. Nothing needs to be checked separately, and new
-workspace packages are picked up automatically — they only need their own
-`typecheck` script, which `tests/unit/workspace-typecheck-coverage.test.ts`
-enforces.
+What it covers: `src/`, `skills/` and `tests/` (three tsconfig projects) plus
+**every workspace package** under `apps/*` and `packages/*`, via `pnpm -r run
+typecheck`. No workspace package needs checking separately, and new ones are
+picked up automatically — they only need their own `typecheck` script, which
+`tests/unit/workspace-typecheck-coverage.test.ts` requires of any package
+shipping `.ts` sources (`pnpm -r` silently *skips* a package that lacks the
+script, so that test is what keeps the skip loud).
+
+What it does **not** cover, so don't read the green as total:
+
+- `scripts/**` — outside all three tsconfig projects. `vitest.config.ts` runs
+  `scripts/**/*.test.ts` as tests, so those files are executed by CI but never
+  typechecked. 13 real errors are sitting there today (#1729).
+- `apps/*/vite.config.ts` — reachable only through a project reference, and
+  plain `tsc --noEmit` does not build references (that needs `tsc -b`).
 
 Use `-C`, not `--prefix`: for pnpm (unlike npm) `--prefix` sets only the install
 location, so workspace resolution still comes from the process CWD and can

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test:shell": "bash tests/setup/test-setup-functions.sh && bash tests/docker/test-pnpm-retry.sh",
     "test:postgres-image": "bash tests/docker/test-postgres-init.sh",
     "test:watch": "vitest",
-    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.skills.json && tsc --noEmit -p tsconfig.tests.json && pnpm --filter @curia/antfarm run typecheck",
+    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.skills.json && tsc --noEmit -p tsconfig.tests.json && pnpm -r run typecheck",
     "lint": "eslint src/ tests/",
     "migrate": "tsx --env-file=.env node_modules/node-pg-migrate/bin/node-pg-migrate.js up --migrations-dir src/db/migrations --migration-file-language sql",
     "smoke": "tsx --env-file=.env tests/smoke/cli.ts",

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
   "exports": {
     ".": "./index.ts"
   }

--- a/packages/shared-types/tsconfig.json
+++ b/packages/shared-types/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  // Type-only package consumed by both the Node backend (module: nodenext) and the
+  // Vite apps (moduleResolution: bundler). Its own check is deliberately standalone
+  // so the package is verified on its own terms rather than only incidentally, via
+  // whichever consumer happens to import it — see #1726.
+  "compilerOptions": {
+    "target": "ES2023",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2023"],
+    "strict": true,
+    "noEmit": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
+  },
+  // `**/*.ts`, not `*.ts`: a top-level-only include would silently drop the package
+  // out of coverage the day it grows a `src/` directory.
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/tests/unit/workspace-typecheck-coverage.test.ts
+++ b/tests/unit/workspace-typecheck-coverage.test.ts
@@ -10,9 +10,19 @@ import * as yaml from 'js-yaml';
 // It now delegates to `pnpm -r run typecheck`, which cannot drift as packages are added.
 // But `pnpm -r run` *silently skips* any package that does not define the script — which
 // would reintroduce the same failure mode one level down. This test makes that skip loud:
-// every workspace package that has a tsconfig.json must declare a `typecheck` script.
+// every workspace package that ships TypeScript must declare a `typecheck` script that
+// actually runs `tsc`.
+//
+// The trigger is "has .ts sources", not "has a tsconfig.json". A package with sources but
+// no tsconfig is exactly the dangerous case: `pnpm -r` skips it and the root projects do
+// not reach it either (they include `src/**`, `skills/**` and `tests/**` only), so it is
+// checked only incidentally, if some consumer happens to import it. That is not coverage.
+//
+// Everything here is written to fail loudly rather than pass vacuously — a guard test that
+// silently inspects nothing is the same defect it exists to catch.
 
 const REPO_ROOT = join(import.meta.dirname, '../..');
+const SKIP_DIRS = new Set(['node_modules', 'dist', 'build', 'coverage', '.git']);
 
 interface PackageJson {
   name?: string;
@@ -21,51 +31,90 @@ interface PackageJson {
 
 /**
  * Resolve the workspace `packages:` globs from pnpm-workspace.yaml into concrete package
- * directories. Only the single-level `dir/*` form is used by this repo, so that is all we
- * expand — a more exotic glob should fail loudly here rather than be silently under-matched.
+ * directories, keyed by the glob that produced them. Only the single-level `dir/*` form is
+ * used by this repo, so that is all we expand — any other form (including pnpm's
+ * `!`-prefixed exclusions, which also end in `/*`) fails here rather than being silently
+ * mis-expanded.
  */
-function workspacePackageDirs(): string[] {
+function workspacePackageDirsByGlob(): Map<string, string[]> {
   const workspaceFile = join(REPO_ROOT, 'pnpm-workspace.yaml');
   const parsed = yaml.load(readFileSync(workspaceFile, 'utf8')) as { packages?: string[] };
   const globs = parsed.packages ?? [];
   expect(globs.length, 'pnpm-workspace.yaml declares no packages').toBeGreaterThan(0);
 
-  const dirs: string[] = [];
+  const byGlob = new Map<string, string[]>();
   for (const glob of globs) {
-    expect(glob.endsWith('/*'), `unsupported workspace glob "${glob}" — update this test`).toBe(
+    expect(
+      glob.endsWith('/*') && !glob.startsWith('!'),
+      `unsupported workspace glob "${glob}" — update this test rather than letting it under-match`,
+    ).toBe(true);
+
+    const parent = join(REPO_ROOT, dirname(glob));
+    // Deliberately not `continue` on a missing parent: if `apps/` is renamed or deleted,
+    // every package under it would vanish from the check with no signal at all.
+    expect(existsSync(parent), `workspace glob "${glob}" resolves to a missing directory`).toBe(
       true,
     );
-    const parent = join(REPO_ROOT, dirname(glob));
-    if (!existsSync(parent)) continue;
+
+    const dirs: string[] = [];
     for (const entry of readdirSync(parent, { withFileTypes: true })) {
-      if (!entry.isDirectory()) continue;
+      if (!entry.isDirectory() || SKIP_DIRS.has(entry.name)) continue;
       const dir = join(parent, entry.name);
       if (existsSync(join(dir, 'package.json'))) dirs.push(dir);
     }
+    expect(dirs.length, `workspace glob "${glob}" matched no packages`).toBeGreaterThan(0);
+    byGlob.set(glob, dirs);
   }
-  return dirs;
+  return byGlob;
+}
+
+/** True if the directory tree holds at least one .ts/.tsx file outside build output. */
+function hasTypeScriptSources(dir: string): boolean {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name)) continue;
+      if (hasTypeScriptSources(join(dir, entry.name))) return true;
+    } else if (/\.tsx?$/.test(entry.name)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 describe('workspace typecheck coverage', () => {
-  it('every workspace package with a tsconfig.json declares a typecheck script', () => {
-    const dirs = workspacePackageDirs();
-    expect(dirs.length, 'no workspace packages discovered').toBeGreaterThan(0);
+  it('every workspace package shipping TypeScript declares a typecheck script that runs tsc', () => {
+    const dirs = [...workspacePackageDirsByGlob().values()].flat();
 
-    const uncovered: string[] = [];
+    const missing: string[] = [];
+    const notRunningTsc: string[] = [];
+    let inspected = 0;
+
     for (const dir of dirs) {
-      // A package without its own tsconfig.json has no project for `tsc --noEmit` to check;
-      // it is covered (or not) by the root projects instead, so it is not our concern here.
-      if (!existsSync(join(dir, 'tsconfig.json'))) continue;
+      if (!hasTypeScriptSources(dir)) continue;
+      inspected++;
 
       const pkg = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8')) as PackageJson;
-      if (!pkg.scripts?.typecheck) {
-        uncovered.push(pkg.name ?? dir);
+      const name = pkg.name ?? dir;
+      const script = pkg.scripts?.typecheck;
+
+      if (!script) {
+        missing.push(name);
+      } else if (!/\btsc\b/.test(script)) {
+        // A `typecheck` script that never invokes tsc (`echo ok`, `exit 0`) satisfies
+        // `pnpm -r` and is green forever — success reported over an unchecked package.
+        notRunningTsc.push(`${name} (${script})`);
       }
     }
 
+    // Without this the assertions below would pass on an empty inspection set.
+    expect(inspected, 'no TypeScript workspace packages were inspected').toBeGreaterThan(0);
     expect(
-      uncovered,
-      `these packages would be silently skipped by \`pnpm -r run typecheck\`: ${uncovered.join(', ')}`,
+      missing,
+      `these packages would be silently skipped by \`pnpm -r run typecheck\`: ${missing.join(', ')}`,
+    ).toEqual([]);
+    expect(
+      notRunningTsc,
+      `these packages declare a typecheck script that never runs tsc: ${notRunningTsc.join(', ')}`,
     ).toEqual([]);
   });
 
@@ -75,7 +124,8 @@ describe('workspace typecheck coverage', () => {
     ) as PackageJson;
     const typecheck = rootPkg.scripts?.typecheck ?? '';
 
-    expect(typecheck).toContain('pnpm -r run typecheck');
+    // Tolerant of added flags (e.g. `--if-present`) but not of losing the recursion.
+    expect(typecheck).toMatch(/pnpm -r\b[^&|]*\brun typecheck\b/);
     // A hand-maintained `--filter <pkg>` list is how console came to be missing in the
     // first place; recursion is the point of the fix.
     expect(typecheck).not.toContain('--filter');

--- a/tests/unit/workspace-typecheck-coverage.test.ts
+++ b/tests/unit/workspace-typecheck-coverage.test.ts
@@ -68,15 +68,48 @@ function workspacePackageDirsByGlob(): Map<string, string[]> {
   return byGlob;
 }
 
-/** True if the directory tree holds at least one .ts/.tsx file outside build output. */
+// Every extension tsc treats as TypeScript input. `.mts`/`.cts` matter as much as `.ts`:
+// a package written entirely in them is just as unchecked, and just as invisible.
+const TS_EXTENSION = /\.(?:[cm]?ts|tsx)$/;
+
+/** True if the directory tree holds at least one TypeScript file outside build output. */
 function hasTypeScriptSources(dir: string): boolean {
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     if (entry.isDirectory()) {
       if (SKIP_DIRS.has(entry.name)) continue;
       if (hasTypeScriptSources(join(dir, entry.name))) return true;
-    } else if (/\.tsx?$/.test(entry.name)) {
+    } else if (TS_EXTENSION.test(entry.name)) {
       return true;
     }
+  }
+  return false;
+}
+
+// Wrappers that may precede the real binary: `pnpm exec tsc`, `npx -y tsc`, `pnpm run tsc`.
+const RUNNERS = new Set(['npm', 'npx', 'pnpm', 'pnpx', 'yarn', 'bun', 'bunx', 'exec', 'run', 'dlx']);
+// Invocations that exit 0 without typechecking anything.
+const NON_CHECKING_FLAGS = /^(?:-v|-h|--version|--help|--init|--showConfig)$/i;
+
+/**
+ * True if the script actually *executes* tsc as a typechecking command.
+ *
+ * A substring match is not enough: `echo tsc` and `tsc --version` both contain "tsc",
+ * both exit 0, and both leave the package unchecked while satisfying `pnpm -r` — the
+ * precise shape of #1726, so the guard must not accept them. Split the script into
+ * commands, skip any runner prefix, and require `tsc` to be the command being run
+ * with at least one argument that isn't version/help.
+ */
+function runsTsc(script: string): boolean {
+  for (const segment of script.split(/&&|\|\||[;|]/)) {
+    const words = segment.trim().split(/\s+/).filter(Boolean);
+
+    let i = 0;
+    while (i < words.length && (RUNNERS.has(words[i]!) || words[i]!.startsWith('-'))) i++;
+    if (words[i] !== 'tsc') continue;
+
+    const args = words.slice(i + 1);
+    if (args.some((arg) => NON_CHECKING_FLAGS.test(arg))) continue;
+    return true;
   }
   return false;
 }
@@ -99,9 +132,10 @@ describe('workspace typecheck coverage', () => {
 
       if (!script) {
         missing.push(name);
-      } else if (!/\btsc\b/.test(script)) {
-        // A `typecheck` script that never invokes tsc (`echo ok`, `exit 0`) satisfies
-        // `pnpm -r` and is green forever — success reported over an unchecked package.
+      } else if (!runsTsc(script)) {
+        // A `typecheck` script that never really invokes tsc (`echo ok`, `exit 0`,
+        // `tsc --version`) satisfies `pnpm -r` and is green forever — success reported
+        // over an unchecked package.
         notRunningTsc.push(`${name} (${script})`);
       }
     }

--- a/tests/unit/workspace-typecheck-coverage.test.ts
+++ b/tests/unit/workspace-typecheck-coverage.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import * as yaml from 'js-yaml';
+
+// Guard for #1726. The root `typecheck` script used to enumerate workspace packages by
+// hand (`pnpm --filter @curia/antfarm run typecheck`) and had drifted: `apps/console` was
+// never checked, so the documented command reported success over real type errors.
+//
+// It now delegates to `pnpm -r run typecheck`, which cannot drift as packages are added.
+// But `pnpm -r run` *silently skips* any package that does not define the script — which
+// would reintroduce the same failure mode one level down. This test makes that skip loud:
+// every workspace package that has a tsconfig.json must declare a `typecheck` script.
+
+const REPO_ROOT = join(import.meta.dirname, '../..');
+
+interface PackageJson {
+  name?: string;
+  scripts?: Record<string, string>;
+}
+
+/**
+ * Resolve the workspace `packages:` globs from pnpm-workspace.yaml into concrete package
+ * directories. Only the single-level `dir/*` form is used by this repo, so that is all we
+ * expand — a more exotic glob should fail loudly here rather than be silently under-matched.
+ */
+function workspacePackageDirs(): string[] {
+  const workspaceFile = join(REPO_ROOT, 'pnpm-workspace.yaml');
+  const parsed = yaml.load(readFileSync(workspaceFile, 'utf8')) as { packages?: string[] };
+  const globs = parsed.packages ?? [];
+  expect(globs.length, 'pnpm-workspace.yaml declares no packages').toBeGreaterThan(0);
+
+  const dirs: string[] = [];
+  for (const glob of globs) {
+    expect(glob.endsWith('/*'), `unsupported workspace glob "${glob}" — update this test`).toBe(
+      true,
+    );
+    const parent = join(REPO_ROOT, dirname(glob));
+    if (!existsSync(parent)) continue;
+    for (const entry of readdirSync(parent, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      const dir = join(parent, entry.name);
+      if (existsSync(join(dir, 'package.json'))) dirs.push(dir);
+    }
+  }
+  return dirs;
+}
+
+describe('workspace typecheck coverage', () => {
+  it('every workspace package with a tsconfig.json declares a typecheck script', () => {
+    const dirs = workspacePackageDirs();
+    expect(dirs.length, 'no workspace packages discovered').toBeGreaterThan(0);
+
+    const uncovered: string[] = [];
+    for (const dir of dirs) {
+      // A package without its own tsconfig.json has no project for `tsc --noEmit` to check;
+      // it is covered (or not) by the root projects instead, so it is not our concern here.
+      if (!existsSync(join(dir, 'tsconfig.json'))) continue;
+
+      const pkg = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8')) as PackageJson;
+      if (!pkg.scripts?.typecheck) {
+        uncovered.push(pkg.name ?? dir);
+      }
+    }
+
+    expect(
+      uncovered,
+      `these packages would be silently skipped by \`pnpm -r run typecheck\`: ${uncovered.join(', ')}`,
+    ).toEqual([]);
+  });
+
+  it('the root typecheck script delegates recursively rather than naming packages', () => {
+    const rootPkg = JSON.parse(
+      readFileSync(join(REPO_ROOT, 'package.json'), 'utf8'),
+    ) as PackageJson;
+    const typecheck = rootPkg.scripts?.typecheck ?? '';
+
+    expect(typecheck).toContain('pnpm -r run typecheck');
+    // A hand-maintained `--filter <pkg>` list is how console came to be missing in the
+    // first place; recursion is the point of the fix.
+    expect(typecheck).not.toContain('--filter');
+  });
+});


### PR DESCRIPTION
Closes #1726.

## What was wrong

`pnpm run typecheck` enumerated workspace packages by hand:

```
tsc --noEmit && ... && pnpm --filter @curia/antfarm run typecheck
```

That list had drifted. `apps/console` was never in it, so the command CLAUDE.md names as *the*
typecheck returned clean while real errors sat in the console — two `noUnusedLocals` errors during
#1724 got through it and surfaced only when the console project was run directly.

## The fix

```diff
-pnpm --filter @curia/antfarm run typecheck
+pnpm -r run typecheck
```

#1726 offered the explicit form (`&& pnpm --filter @curia/console run typecheck`) or the recursive
one and called either fine. I took the recursive form, because the issue's own framing is that
*drift is the thing worth designing against* and only recursion makes the drift structurally
impossible.

CI's separate `Type check console` step is folded into the root step for the same reason: a second
hand-maintained list is a second thing to forget. (It was also silently skippable in its own right
— `pnpm --filter @curia/nope run typecheck` exits **0** with a warning, so a rename would have made
that step pass while checking nothing.)

## The catch, and what closes it

`pnpm -r run` **silently skips** any package that doesn't define the script. Left alone that just
moves the bug one level down, so this PR adds `tests/unit/workspace-typecheck-coverage.test.ts`:
every workspace package shipping `.ts` must declare a `typecheck` script that actually runs `tsc`.

Review caught that the hole was not hypothetical — it was **live on the first commit**.
`packages/shared-types` had no `typecheck` script and no `tsconfig.json`, so it was skipped twice:
by `pnpm -r`, and by the guard test, whose trigger was originally "has a `tsconfig.json`". Its
types were checked only *incidentally*, because `src/` imports them; delete that one import and the
package goes unchecked with every gate still green. Fixed by giving it its own tsconfig and
typecheck script, and by changing the guard's trigger to "has `.ts` sources" — the condition that
actually matters.

The guard is also hardened against passing vacuously, since a guard test that inspects nothing is
the exact defect it exists to catch:

| Failure mode | Before | Now |
|---|---|---|
| Package with `.ts` but no `typecheck` script | skipped if it had no tsconfig | fails, named |
| `"typecheck": "echo ok"` | passed | fails, named |
| `apps/` renamed or deleted | silently skipped, green | fails |
| A glob matching zero packages | silently green | fails |
| Zero packages inspected overall | silently green | fails |
| `!`-prefixed exclusion glob | expanded as an include | rejected |

## Honesty about what is *not* covered

The first draft of the CLAUDE.md rewrite said "this one command is complete — nothing needs to be
checked separately". That was false, and worth calling out explicitly: a document asserting no list
is needed, while a gap persists, is the original bug with the evidence removed.

Two real gaps remain and are now named in both CLAUDE.md and AGENTS.md instead of papered over:

- **`scripts/**` is typechecked by nothing** — outside all three tsconfig projects, with **13 live
  type errors**, several of them genuine bit-rot (`Contact.status`, `Contact.trustLevel` and
  `Config.security` no longer exist). Four of those files are `scripts/**/*.test.ts`, which
  `vitest.config.ts` includes — so CI *runs* them as tests but never typechecks them. Filed as
  **#1729**; deliberately not bundled here, since fixing it means touching 13 real errors.
- **`apps/*/vite.config.ts`** — reachable only through a project reference, and plain
  `tsc --noEmit` does not build references (needs `tsc -b`).

## Also in here

- `AGENTS.md` still instructed readers to run `pnpm --filter @curia/console run typecheck`
  separately — the very habit this PR removes, and it contradicted the updated CLAUDE.md.
- CLAUDE.md's type-checking line said `pnpm --prefix <worktree>`; corrected to `pnpm -C`. For pnpm
  (unlike npm) `--prefix` sets only the install location, leaving workspace resolution to the
  process CWD. Drive-by on a line already being edited — say the word and I'll split it out.
- CHANGELOG entry trimmed to the documented 15-word cap.

## Verification

Every acceptance criterion in #1726, by deliberately introducing a type error and confirming a
non-zero exit, then removing it:

| Probe | Root `typecheck` exit |
|---|---|
| `src/` | 2 |
| `tests/` | 2 |
| `skills/` | 2 |
| `apps/antfarm/src/` | 2 |
| `apps/console/src/` | 2 ← the bug |
| `packages/shared-types/` | 2 ← found during review |
| clean tree | **0** |

Guard test verified in both directions — green as-is, and failing with the right message when the
console script is removed, when a script is replaced with `echo ok`, and when a workspace glob is
pointed at a missing directory.

`pnpm run lint` clean. `pnpm run typecheck` exit 0.

## One thing to know about the test suite

The full suite goes green (`545 passed`, `6627 tests`), but **not reliably** — repeated runs fail a
*different* integration file each time on FK/PK violations in shared tables (`setup-routes`,
`contact-merge-kg`, `autonomy-service-pagination`, `knowledge-graph`, `extract-facts`…).

I checked whether this PR caused it by running the suite on unmodified `main` in a separate
worktree: **run 1 green, run 2 failed** `extract-facts`. So it is pre-existing — vitest runs files
in parallel against one Postgres while tests `DELETE FROM` shared tables. CI has the same shape
(`pnpm test` against a single postgres service), so CI is presumably flaky too. Not touched here;
happy to file it if you want it tracked.
