### PR TITLE
chore: typecheck scripts/ and vitest.config.ts, fix the 13 errors that had accumulated

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,11 +62,13 @@ caveats; standard commands live in `package.json` scripts and `scripts/setup.sh`
 - Lint: `pnpm run lint` — covers `src/`, `tests/` and `apps/`. The browser apps get their
   own `eslint.config.js` block: no `no-console` there (pino is a Node logger), plus the
   React hooks rules. Not covered: `skills/**`, `scripts/**` and `packages/**`.
-- Typecheck: `pnpm run typecheck` — 3 root tsconfigs (`src/`,
-  `skills/`, `tests/`) plus **every** workspace package under `apps/*` and `packages/*`
+- Typecheck: `pnpm run typecheck` — 4 root tsconfigs (`src/`, `skills/`, `tests/`,
+  `scripts/`) plus **every** workspace package under `apps/*` and `packages/*`
   via `pnpm -r run typecheck`. No workspace package is checked separately; a per-package
-  list here is how `apps/console` came to be missed (#1726). Not covered: `scripts/**`
-  (#1729) and `apps/*/vite.config.ts` (which lint *does* cover). Build console:
+  list here is how `apps/console` came to be missed (#1726). `tests/unit/root-typecheck-coverage.test.ts`
+  fails if a TypeScript file outside the workspace packages lands in none of the root
+  projects (#1729). Not covered: `apps/*/vite.config.ts` — reachable only via a project
+  reference, which plain `tsc --noEmit` does not build (lint *does* cover it). Build console:
   `pnpm --filter @curia/console run build`.
 - Tests: `pnpm test` (vitest). Integration tests **require `DATABASE_URL`** and applied
   migrations; they `describe.skip` when it is unset. Mirror CI by using a separate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 - **Vitest `.tsx` coverage** — component tests now run; `VoiceCallBar.test.tsx` had never executed. (#1727)
 - **Root `typecheck` coverage** — now recurses over every workspace package; `apps/console` was silently skipped. (#1726)
-- **`scripts/` typecheck coverage** — a fourth tsconfig project checks maintenance scripts and `vitest.config.ts`. (#1729)
+- **`scripts/` typecheck coverage** — maintenance scripts get a strict tsconfig project; their tests and `vitest.config.ts` join the tests project. (#1729)
 - **`dedup-contacts` schema rot** — the sweep queried `status`/`trust_level`, dropped in migration 059; it now filters on tier. (#1729)
 - **Prompt scripts read the wrong config** — trust thresholds come from the YAML config, not the env-derived one. (#1729)
 - **`docker-publish` `:latest`** — pinned `flavor: latest=false`; a dispatched re-publish no longer moves `latest` backwards. (#1718)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,9 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 - **Vitest `.tsx` coverage** — component tests now run; `VoiceCallBar.test.tsx` had never executed. (#1727)
 - **Root `typecheck` coverage** — now recurses over every workspace package; `apps/console` was silently skipped. (#1726)
+- **`scripts/` typecheck coverage** — a fourth tsconfig project checks maintenance scripts and `vitest.config.ts`. (#1729)
+- **`dedup-contacts` schema rot** — the sweep queried `status`/`trust_level`, dropped in migration 059; it now filters on tier. (#1729)
+- **Prompt scripts read the wrong config** — trust thresholds come from the YAML config, not the env-derived one. (#1729)
 - **`docker-publish` `:latest`** — pinned `flavor: latest=false`; a dispatched re-publish no longer moves `latest` backwards. (#1718)
 - **`docker-publish` re-publish** — the ref-dropdown form now resolves and validates its tag like the input form. (#1718)
 - **`docker-publish` dispatch** — a dispatch that would publish nothing, or name a tag from an unrelated branch, is refused. (#1718)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,19 +31,28 @@ Always run `pnpm -C <worktree> run typecheck` (not raw `tsc --noEmit`) —
 CI uses `pnpm run typecheck` which may resolve a different tsconfig chain than
 a bare `tsc` invocation. Run this before every commit that touches `.ts` files.
 
-What it covers: `src/`, `skills/` and `tests/` (three tsconfig projects) plus
-**every workspace package** under `apps/*` and `packages/*`, via `pnpm -r run
-typecheck`. No workspace package needs checking separately, and new ones are
-picked up automatically — they only need their own `typecheck` script, which
-`tests/unit/workspace-typecheck-coverage.test.ts` requires of any package
+What it covers: `src/`, `skills/`, `tests/` and `scripts/` (four tsconfig
+projects) plus **every workspace package** under `apps/*` and `packages/*`, via
+`pnpm -r run typecheck`. No workspace package needs checking separately, and new
+ones are picked up automatically — they only need their own `typecheck` script,
+which `tests/unit/workspace-typecheck-coverage.test.ts` requires of any package
 shipping `.ts` sources (`pnpm -r` silently *skips* a package that lacks the
 script, so that test is what keeps the skip loud).
 
+The root projects have the mirror-image failure mode: a file in no project at
+all is checked by nothing and reports green forever (that was `scripts/**` and
+`vitest.config.ts`, with 13 live errors, until #1729).
+`tests/unit/root-typecheck-coverage.test.ts` keeps that loud too — it fails if
+any TypeScript file outside the workspace packages is absent from every root
+project. A new top-level tree therefore needs a home in a tsconfig on day one.
+
+Non-test files under `scripts/**` live in `tsconfig.scripts.json`, which keeps
+the base project's strict settings — they are maintenance tools run against
+production. `scripts/**/*.test.ts` and `vitest.config.ts` are in
+`tsconfig.tests.json` with the relaxations mock-heavy test code needs.
+
 What it does **not** cover, so don't read the green as total:
 
-- `scripts/**` — outside all three tsconfig projects. `vitest.config.ts` runs
-  `scripts/**/*.test.ts` as tests, so those files are executed by CI but never
-  typechecked. 13 real errors are sitting there today (#1729).
 - `apps/*/vite.config.ts` — reachable only through a project reference, and
   plain `tsc --noEmit` does not build references (that needs `tsc -b`).
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test:shell": "bash tests/setup/test-setup-functions.sh && bash tests/docker/test-pnpm-retry.sh",
     "test:postgres-image": "bash tests/docker/test-postgres-init.sh",
     "test:watch": "vitest",
-    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.skills.json && tsc --noEmit -p tsconfig.tests.json && pnpm -r run typecheck",
+    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.skills.json && tsc --noEmit -p tsconfig.tests.json && tsc --noEmit -p tsconfig.scripts.json && pnpm -r run typecheck",
     "lint": "eslint src/ tests/ apps/",
     "migrate": "tsx --env-file=.env node_modules/node-pg-migrate/bin/node-pg-migrate.js up --migrations-dir src/db/migrations --migration-file-language sql",
     "smoke": "tsx --env-file=.env tests/smoke/cli.ts",

--- a/scripts/dedup-contacts.test.ts
+++ b/scripts/dedup-contacts.test.ts
@@ -14,7 +14,7 @@
 // Exclusion pair-normalization unit tests live in src/contacts/dedup-exclusions.test.ts;
 // the table itself is covered by tests/integration/contact-dedup-exclusions.test.ts.
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type MockedFunction } from 'vitest';
 import type { Contact, ChannelIdentity } from '../src/contacts/types.js';
 import {
   runDedup,
@@ -34,9 +34,12 @@ function makeContact(
     kgNodeId: null,
     role: null,
     systemRole: null,
-    status: 'confirmed',
+    // tier/kind replaced status/trust_level as the capability axis (#945, columns
+    // dropped in migration 059). 'known' is the ordinary non-blocked tier the sweep
+    // operates on; 'person' matches the classifier's default for a human contact.
+    tier: 'known',
+    kind: 'person',
     contactConfidence: 0.8,
-    trustLevel: null,
     lastSeenAt: null,
     inboundMessageCount: 0,
     outboundMessageCount: 0,
@@ -84,21 +87,24 @@ function makeIdentity(
 // ---------------------------------------------------------------------------
 
 describe('runDedup — unit', () => {
-  let mergeMock: ReturnType<typeof vi.fn>;
-  let createTaskMock: ReturnType<typeof vi.fn>;
-  let listExclusionPairKeysMock: ReturnType<typeof vi.fn>;
+  // Typed from DedupRunOptions rather than `ReturnType<typeof vi.fn>`: the bare form
+  // is `Mock<Procedure | Constructable>`, which does not satisfy the specific call
+  // signatures on the options object.
+  let mergeMock: MockedFunction<DedupRunOptions['mergeContacts']>;
+  let createTaskMock: MockedFunction<DedupRunOptions['createTask']>;
+  let listExclusionPairKeysMock: MockedFunction<DedupRunOptions['listExclusionPairKeys']>;
   let opts: DedupRunOptions;
 
   beforeEach(() => {
-    mergeMock = vi.fn().mockResolvedValue({
+    mergeMock = vi.fn<DedupRunOptions['mergeContacts']>().mockResolvedValue({
       primaryContactId: 'c1',
       secondaryContactId: 'c2',
       goldenRecord: {},
       dryRun: false,
       mergedAt: new Date(),
     });
-    createTaskMock = vi.fn().mockResolvedValue({ id: 'task-1', title: 'test' });
-    listExclusionPairKeysMock = vi.fn().mockResolvedValue(new Set<string>());
+    createTaskMock = vi.fn<DedupRunOptions['createTask']>().mockResolvedValue({ id: 'task-1', title: 'test' });
+    listExclusionPairKeysMock = vi.fn<DedupRunOptions['listExclusionPairKeys']>().mockResolvedValue(new Set<string>());
 
     opts = {
       dryRun: false,

--- a/scripts/dedup-contacts.ts
+++ b/scripts/dedup-contacts.ts
@@ -17,8 +17,7 @@
 import pg from 'pg';
 import { createLogger } from '../src/logger.js';
 import { classifyPair, type PairClassification } from '../src/contacts/dedup-classifier.js';
-import type { Contact, ChannelIdentity, ContactKind } from '../src/contacts/types.js';
-import { meetsMinimumTier } from '../src/contacts/types.js';
+import { meetsMinimumTier, type Contact, type ChannelIdentity, type ContactKind } from '../src/contacts/types.js';
 import {
   canonicalPairKey,
   dedupPairTag,

--- a/scripts/dedup-contacts.ts
+++ b/scripts/dedup-contacts.ts
@@ -18,6 +18,7 @@ import pg from 'pg';
 import { createLogger } from '../src/logger.js';
 import { classifyPair, type PairClassification } from '../src/contacts/dedup-classifier.js';
 import type { Contact, ChannelIdentity, ContactKind } from '../src/contacts/types.js';
+import { meetsMinimumTier } from '../src/contacts/types.js';
 import {
   canonicalPairKey,
   dedupPairTag,
@@ -438,11 +439,9 @@ type ContactRow = {
   display_name: string;
   role: string | null;
   system_role: string | null;
-  status: string;
   tier: string;
   kind: string | null;
   contact_confidence: string;
-  trust_level: string | null;
   last_seen_at: Date | null;
   inbound_message_count: string;
   outbound_message_count: string;
@@ -500,11 +499,9 @@ function rowToContact(row: ContactRow): Contact {
     systemRole: (row.system_role === 'principal' || row.system_role === 'agent' || row.system_role === 'system')
       ? row.system_role
       : null,
-    status: row.status as Contact['status'],
     tier: row.tier as Contact['tier'],
     kind: parseContactKind(row.id, row.kind),
     contactConfidence: Number(row.contact_confidence),
-    trustLevel: row.trust_level as Contact['trustLevel'],
     lastSeenAt: row.last_seen_at,
     inboundMessageCount: Number(row.inbound_message_count),
     outboundMessageCount: Number(row.outbound_message_count),
@@ -546,18 +543,26 @@ async function loadContactsAndIdentities(pool: pg.Pool): Promise<{
   contacts: Contact[];
   identityMap: Map<string, ChannelIdentity[]>;
 }> {
-  // Load only 'confirmed' and 'provisional' contacts — skip 'blocked'.
-  // Blocked contacts should not be merged; they are deliberately excluded.
+  // Load every contact, then drop the blocked ones — blocked contacts must not be
+  // merged, and they are deliberately excluded.
+  //
+  // The filter is applied in JS rather than SQL so it can go through meetsMinimumTier()
+  // instead of naming tiers in a WHERE clause: 'unknown' is the lowest non-blocked tier,
+  // so "meets minimum 'unknown'" is exactly "not blocked" and stays correct if the tier
+  // ladder is ever reordered. This replaced `WHERE status IN ('confirmed','provisional')`
+  // — contacts.status was dropped in migration 059 (#955/#1070), so that query had been
+  // failing outright against any migrated database (#1729).
   const contactsResult = await pool.query<ContactRow>(
-    `SELECT id, kg_node_id, display_name, role, system_role, status, tier, kind, contact_confidence,
-            trust_level, last_seen_at, inbound_message_count, outbound_message_count, notes,
+    `SELECT id, kg_node_id, display_name, role, system_role, tier, kind, contact_confidence,
+            last_seen_at, inbound_message_count, outbound_message_count, notes,
             created_at, updated_at, preferred_name, title, organization, primary_email,
             primary_phone, timezone, locale, location, pronouns, linkedin_url, bio, birthday
      FROM contacts
-     WHERE status IN ('confirmed', 'provisional')
      ORDER BY created_at ASC`,
   );
-  const contacts = contactsResult.rows.map(rowToContact);
+  const contacts = contactsResult.rows
+    .map(rowToContact)
+    .filter((contact) => meetsMinimumTier(contact.tier, 'unknown'));
 
   // Load all identities for the fetched contacts in one query.
   // The contact IDs are parameterized via ANY($1) to avoid string interpolation.

--- a/scripts/inspect-prompts.ts
+++ b/scripts/inspect-prompts.ts
@@ -27,7 +27,7 @@
 
 import { resolve } from 'node:path';
 import pg from 'pg';
-import { loadConfig } from '../src/config.js';
+import { loadYamlConfig } from '../src/config.js';
 import { loadAllAgentConfigs } from '../src/agents/loader.js';
 import { AgentRegistry } from '../src/agents/agent-registry.js';
 import { OfficeIdentityService } from '../src/identity/service.js';
@@ -51,7 +51,10 @@ async function main(): Promise<void> {
   // (update/reload paths), which never happen here.
   const bus = new EventBus(logger);
 
-  const config = loadConfig();
+  // Trust thresholds live in the YAML config (config/default.yaml), not in the
+  // env-derived Config that loadConfig() returns. This script read the wrong one and
+  // silently fell back to the hardcoded defaults below (#1729).
+  const yamlConfig = loadYamlConfig(CONFIG_DIR);
   const pool = new pg.Pool({ connectionString: databaseUrl });
 
   // Declared outside try so the finally block can call stop() on each service.
@@ -123,7 +126,7 @@ async function main(): Promise<void> {
     // Read from config the same way index.ts does. The defaults here match
     // Curia's hardcoded fallbacks so the output is correct even without a
     // config/default.yaml override.
-    const rawThresholds = config.security?.trust_thresholds;
+    const rawThresholds = yamlConfig.security?.trust_thresholds;
     const thresholds = {
       information_query: rawThresholds?.information_query ?? 0.30,
       scheduling:        rawThresholds?.scheduling        ?? 0.50,

--- a/scripts/render-coordinator-prompt.ts
+++ b/scripts/render-coordinator-prompt.ts
@@ -13,7 +13,6 @@
 // Re-run when any of the following change:
 //   - agents/coordinator.yaml system_prompt
 //   - Office identity (wizard / PUT /api/identity)
-//   - config/executive-profile.yaml or executive profile via API
 //   - security.trust_thresholds in config/default.yaml
 //   - Specialist agents (agents/*.yaml)
 //
@@ -21,11 +20,10 @@
 
 import { resolve } from 'node:path';
 import pg from 'pg';
-import { loadConfig } from '../src/config.js';
+import { loadConfig, loadYamlConfig } from '../src/config.js';
 import { loadAllAgentConfigs, interpolateRuntimeContext } from '../src/agents/loader.js';
 import { AgentRegistry } from '../src/agents/agent-registry.js';
 import { OfficeIdentityService } from '../src/identity/service.js';
-import { ExecutiveProfileService, compileWritingVoiceBlock } from '../src/executive/service.js';
 import { compileSecurityContextBlock } from '../src/security/security-context.js';
 import { formatTimeContextBlock } from '../src/time/time-context.js';
 import { EventBus } from '../src/bus/bus.js';
@@ -45,42 +43,23 @@ async function main(): Promise<void> {
   // No-op bus — this script only reads; services only use the bus for write paths.
   const bus = new EventBus(logger);
   const config = loadConfig();
+  // Trust thresholds live in the YAML config (config/default.yaml), not in the
+  // env-derived Config that loadConfig() returns. This script read the wrong one and
+  // silently fell back to the hardcoded defaults below (#1729).
+  const yamlConfig = loadYamlConfig(CONFIG_DIR);
   const pool = new pg.Pool({ connectionString: databaseUrl });
 
   let identityService: OfficeIdentityService | null = null;
-  let profileService: ExecutiveProfileService | null = null;
 
   try {
     // ── Identity block ─────────────────────────────────────────────────────────
     identityService = new OfficeIdentityService(pool, logger, bus);
     await identityService.initialize();
 
-    // ── Executive voice block ──────────────────────────────────────────────────
-    profileService = new ExecutiveProfileService(
-      pool,
-      logger,
-      bus,
-      resolve(CONFIG_DIR, 'executive-profile.yaml'),
-    );
-    await profileService.initialize();
-
-    // Resolve the principal's display name by system_role — the single source of truth
-    // (#1049). Mirrors how index.ts resolves the principal contact at startup.
-    let executiveDisplayName = 'the executive';
-    const nameResult = await pool.query<{ display_name: string }>(
-      `SELECT display_name FROM contacts WHERE system_role = 'principal' LIMIT 1`,
-    );
-    const principalRow = nameResult.rows[0];
-    if (principalRow?.display_name) {
-      executiveDisplayName = principalRow.display_name;
-    } else {
-      // Warn rather than fail — name is cosmetic; a fallback won't invalidate red-team results.
-      process.stderr.write(
-        'render-coordinator-prompt: warning: no principal contact found.\n' +
-        '  Executive display name will be "the executive" in the rendered prompt.\n' +
-        '  Has the onboarding wizard been completed on this instance?\n',
-      );
-    }
+    // No ExecutiveProfileService here: the ${executive_voice_block} injection it fed was
+    // removed in #957, so loading the profile (and starting its file watcher) would render
+    // a prompt block the runtime never emits. The principal's *contact* details below still
+    // come from the DB, which is what the runtime actually injects.
 
     // ── Agent contact ID + channel identities ─────────────────────────────────
     const agentResult = await pool.query<{ id: string }>(
@@ -143,7 +122,7 @@ async function main(): Promise<void> {
     }
 
     // ── Security context block ─────────────────────────────────────────────────
-    const rawThresholds = config.security?.trust_thresholds;
+    const rawThresholds = yamlConfig.security?.trust_thresholds;
     const thresholds = {
       information_query: rawThresholds?.information_query ?? 0.30,
       scheduling:        rawThresholds?.scheduling        ?? 0.50,
@@ -160,11 +139,14 @@ async function main(): Promise<void> {
     }
 
     // interpolateRuntimeContext handles: ${office_identity_block},
-    // ${executive_voice_block}, ${available_specialists}, ${agent_contact_id},
-    // ${principal_contact_id}. The security_context_block is compiled separately.
+    // ${available_specialists}, ${agent_contact_id}, ${principal_contact_id}.
+    // The security_context_block is compiled separately.
+    //
+    // ${executive_voice_block} is deliberately absent: the injection path was removed
+    // in #957 and the placeholder is gone from coordinator.yaml, so passing a voice
+    // block here would render a prompt the runtime never actually produces.
     let systemPrompt = interpolateRuntimeContext(coordinatorConfig.system_prompt, {
       officeIdentityBlock:   identityService.compileSystemPromptBlock(),
-      executiveVoiceBlock:   compileWritingVoiceBlock(profileService.get(), executiveDisplayName),
       availableSpecialists:  registry.specialistSummary(),
       agentContactId,
       principalContactId,
@@ -238,7 +220,6 @@ async function main(): Promise<void> {
     process.stdout.write(perTurnSection + '\n\n' + systemPrompt + '\n');
   } finally {
     await identityService?.stop();
-    await profileService?.stop();
     try {
       await pool.end();
     } catch (err: unknown) {

--- a/scripts/spikes/voice-brain-parity/run.ts
+++ b/scripts/spikes/voice-brain-parity/run.ts
@@ -902,11 +902,15 @@ function aggregateVariance(reps: RepSummary[], arms: ArmId[]) {
     byCategory: {},
   };
 
-  const pairs: Array<{ key: string; a: ArmId; b: ArmId }> = [
+  // The annotation has to sit on the array literal, not on the result of .filter():
+  // with it on `pairs`, the literal gets no contextual type, the arm names widen to
+  // `string`, and the assignment back to ArmId fails.
+  const allPairs: Array<{ key: string; a: ArmId; b: ArmId }> = [
     { key: 'shared-hardening−baseline', a: 'shared-hardening', b: 'baseline' },
     { key: 'shared-hardening−full-consolidation', a: 'shared-hardening', b: 'full-consolidation' },
     { key: 'baseline−full-consolidation', a: 'baseline', b: 'full-consolidation' },
-  ].filter(p => arms.includes(p.a) && arms.includes(p.b));
+  ];
+  const pairs = allPairs.filter(p => arms.includes(p.a) && arms.includes(p.b));
 
   for (const { key, a, b } of pairs) {
     const checkDeltas = reps.map(rep => {

--- a/tests/unit/root-typecheck-coverage.test.ts
+++ b/tests/unit/root-typecheck-coverage.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { join, dirname, relative, resolve, sep } from 'node:path';
+import * as yaml from 'js-yaml';
+import ts from 'typescript';
+
+// Guard for #1729, the root-project counterpart to the workspace-package guard in
+// workspace-typecheck-coverage.test.ts.
+//
+// The root `typecheck` script runs a fixed set of tsconfig projects (`src/**`,
+// `skills/**`, `tests/**`) and then `pnpm -r run typecheck` for the workspace packages.
+// Anything that is neither inside one of those projects nor inside a workspace package
+// is checked by *nothing* — which is exactly where `scripts/**` and `vitest.config.ts`
+// sat: 13 live type errors in maintenance tools that get run against production, plus
+// four test files that CI executes on every PR but never typechecked.
+//
+// Rather than assert the current file list (which would need editing every time a file
+// is added), this derives the projects from the root `typecheck` script and asserts that
+// every TypeScript file outside the workspace packages lands in at least one of them.
+// A new top-level tree is therefore covered on day one or fails here.
+
+const REPO_ROOT = join(import.meta.dirname, '../..');
+const SKIP_DIRS = new Set(['node_modules', 'dist', 'build', 'coverage', '.git']);
+// Every extension tsc treats as input, matching the workspace guard.
+const TS_EXTENSION = /\.(?:[cm]?ts|tsx)$/;
+// Ambient declarations are inputs to whichever project references them; they carry no
+// checkable code of their own and are pulled in implicitly, so they are not the gap.
+const DECLARATION_EXTENSION = /\.d\.[cm]?ts$/;
+
+interface PackageJson {
+  scripts?: Record<string, string>;
+}
+
+/**
+ * The tsconfig projects the root `typecheck` script actually runs, in script order.
+ *
+ * Derived from the script rather than hardcoded: a project added to the repo but never
+ * wired into `typecheck` provides no coverage, and this test must see the same set CI
+ * does. A bare `tsc --noEmit` (no `-p`) means the default `tsconfig.json`.
+ */
+function rootTypecheckProjects(): string[] {
+  const pkg = JSON.parse(readFileSync(join(REPO_ROOT, 'package.json'), 'utf8')) as PackageJson;
+  const script = pkg.scripts?.typecheck;
+  expect(script, 'root package.json declares no typecheck script').toBeTruthy();
+
+  const projects: string[] = [];
+  for (const segment of script!.split(/&&|\|\||[;|]/)) {
+    const words = segment.trim().split(/\s+/).filter(Boolean);
+    // Skip runner prefixes (`pnpm exec tsc`, `npx tsc`) the way the workspace guard does.
+    let i = 0;
+    while (i < words.length && words[i] !== 'tsc') i++;
+    if (words[i] !== 'tsc') continue;
+
+    const args = words.slice(i + 1);
+    const flag = args.findIndex((arg) => arg === '-p' || arg === '--project');
+    projects.push(flag === -1 ? 'tsconfig.json' : args[flag + 1]!);
+  }
+
+  expect(projects.length, 'no tsc invocations found in the root typecheck script').toBeGreaterThan(
+    0,
+  );
+  return projects;
+}
+
+/** Absolute paths of the workspace package directories (`apps/*`, `packages/*`). */
+function workspacePackageDirs(): string[] {
+  const parsed = yaml.load(readFileSync(join(REPO_ROOT, 'pnpm-workspace.yaml'), 'utf8')) as {
+    packages?: string[];
+  };
+  const globs = parsed.packages ?? [];
+  expect(globs.length, 'pnpm-workspace.yaml declares no packages').toBeGreaterThan(0);
+
+  const dirs: string[] = [];
+  for (const glob of globs) {
+    expect(
+      glob.endsWith('/*') && !glob.startsWith('!'),
+      `unsupported workspace glob "${glob}" — update this test rather than letting it over-match`,
+    ).toBe(true);
+
+    const parent = join(REPO_ROOT, dirname(glob));
+    expect(existsSync(parent), `workspace glob "${glob}" resolves to a missing directory`).toBe(
+      true,
+    );
+    for (const entry of readdirSync(parent, { withFileTypes: true })) {
+      if (!entry.isDirectory() || SKIP_DIRS.has(entry.name)) continue;
+      const dir = join(parent, entry.name);
+      if (existsSync(join(dir, 'package.json'))) dirs.push(dir);
+    }
+  }
+  expect(dirs.length, 'no workspace packages resolved').toBeGreaterThan(0);
+  return dirs;
+}
+
+/** Every TypeScript file under `dir`, recursively, skipping build output and `skip`ped trees. */
+function collectTsFiles(dir: string, skip: Set<string>, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name) || skip.has(full)) continue;
+      collectTsFiles(full, skip, out);
+    } else if (TS_EXTENSION.test(entry.name) && !DECLARATION_EXTENSION.test(entry.name)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/**
+ * The root files of a tsconfig project — its `include`/`files` globs resolved against
+ * disk, which is what tsc itself starts from.
+ *
+ * Deliberately *not* the transitive import closure. `scripts/seed-vault.ts` was reached
+ * only because a test happened to import it; delete that import and the file silently
+ * leaves the check. Incidental coverage is not coverage, so it does not count here.
+ */
+function projectFiles(project: string): string[] {
+  const configPath = join(REPO_ROOT, project);
+  expect(
+    existsSync(configPath),
+    `typecheck script runs "${project}" but no such tsconfig exists`,
+  ).toBe(true);
+
+  const parsed = ts.getParsedCommandLineOfConfigFile(configPath, undefined, {
+    ...ts.sys,
+    onUnRecoverableConfigFileDiagnostic: (d) => {
+      throw new Error(
+        `could not parse ${project}: ${ts.flattenDiagnosticMessageText(d.messageText, ' ')}`,
+      );
+    },
+  });
+  expect(parsed, `could not parse ${project}`).toBeTruthy();
+  return parsed!.fileNames.map((f) => resolve(f));
+}
+
+describe('root typecheck coverage', () => {
+  it('every TypeScript file outside the workspace packages is in a root tsconfig project', () => {
+    const skip = new Set(workspacePackageDirs());
+    const candidates = collectTsFiles(REPO_ROOT, skip);
+    // Without this the assertion below would pass on an empty candidate set — the same
+    // vacuous-green failure mode the guard exists to catch.
+    expect(candidates.length, 'no TypeScript files were inspected').toBeGreaterThan(0);
+
+    const covered = new Set(rootTypecheckProjects().flatMap(projectFiles));
+    const uncovered = candidates
+      .filter((file) => !covered.has(file))
+      .map((file) => relative(REPO_ROOT, file));
+
+    expect(
+      uncovered,
+      `these files are typechecked by nothing — no root tsconfig project includes them, ` +
+        `and they are not in a workspace package: ${uncovered.join(', ')}`,
+    ).toEqual([]);
+  });
+
+  it('scripts/ is covered specifically, since those tools run against production', () => {
+    // The general assertion above would also be satisfied by dropping scripts/ from the
+    // repo. This pins the case that motivated #1729 so the coverage cannot quietly narrow.
+    const covered = new Set(rootTypecheckProjects().flatMap(projectFiles));
+    const scriptFiles = collectTsFiles(join(REPO_ROOT, 'scripts'), new Set());
+
+    expect(scriptFiles.length, 'no files found under scripts/').toBeGreaterThan(0);
+    // Both halves matter and land in different projects: the tools in
+    // tsconfig.scripts.json, their tests in tsconfig.tests.json.
+    expect(
+      scriptFiles.some((f) => f.endsWith('.test.ts')),
+      'no test files found under scripts/ — vitest runs them, so they must be checked',
+    ).toBe(true);
+
+    const uncovered = scriptFiles
+      .filter((file) => !covered.has(file))
+      .map((file) => relative(REPO_ROOT, file).split(sep).join('/'));
+    expect(uncovered, `uncovered scripts/ files: ${uncovered.join(', ')}`).toEqual([]);
+  });
+});

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -1,0 +1,29 @@
+{
+  // Type-check the scripts/ tree, which sits outside the main tsconfig's `src/**`
+  // rootDir, outside tsconfig.skills.json's `skills/**`, and outside
+  // tsconfig.tests.json's `tests/**`. scripts/ is also not a workspace package, so
+  // the recursive `pnpm -r run typecheck` pass added in #1726 never reached it
+  // either — the whole tree was checked by nothing. This is #1729.
+  //
+  // These are operational maintenance tools that get run against production, so they
+  // keep the base project's STRICT settings (noUncheckedIndexedAccess, noUnusedLocals,
+  // noUnusedParameters) rather than inheriting the relaxations in tsconfig.tests.json.
+  // Their *tests* are a different matter and live in tsconfig.tests.json, where the
+  // mock-heavy relaxations apply.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true,
+    // declaration/declarationMap/outDir are meaningless for a noEmit check and the
+    // base values (rootDir: src) conflict with this wider rootDir — null them out.
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": false,
+    "composite": false
+  },
+  // Scripts import from ../src, so tsc follows those references automatically.
+  "include": ["scripts/**/*.ts"],
+  // scripts/**/*.test.ts is covered by tsconfig.tests.json instead — test code needs
+  // the relaxed indexed-access/unused-locals rules that project provides.
+  "exclude": ["node_modules", "dist", "scripts/**/*.test.ts"]
+}

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -27,6 +27,17 @@
   },
   // Covers all test source files. Test handlers import from ../../src (or ../src),
   // so tsc follows those references automatically.
-  "include": ["tests/**/*.ts", "src/**/*.test.ts", "apps/**/*.test.ts"],
+  //
+  // scripts/**/*.test.ts is here rather than in tsconfig.scripts.json because it is
+  // mock-heavy test code that wants this project's relaxed rules — and because
+  // vitest.config.ts already runs those files on every PR (#1729). vitest.config.ts
+  // itself is included for the same reason: it was in nobody's project either.
+  "include": [
+    "tests/**/*.ts",
+    "src/**/*.test.ts",
+    "apps/**/*.test.ts",
+    "scripts/**/*.test.ts",
+    "vitest.config.ts"
+  ],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary

`scripts/**` and `vitest.config.ts` were in no tsconfig project and in no workspace package, so `pnpm run typecheck` never looked at them. Fifteen files, thirteen live type errors, and four of those files are tests `vitest.config.ts` runs on every PR.

This adds the missing coverage, fixes the errors it surfaces (they are real bit-rot, not noise), and adds a guard so a new top-level tree cannot repeat the trick.

Closes #1729

## Where the files landed

- **`tsconfig.scripts.json`** (new) — non-test files under `scripts/**`, on the base project's **strict** settings. These are maintenance tools run against production; inheriting `tsconfig.tests.json`'s relaxed `noUnusedLocals` / `noUncheckedIndexedAccess` would undersell them.
- **`tsconfig.tests.json`** — gains `scripts/**/*.test.ts` and `vitest.config.ts`, where the mock-heavy relaxations belong.
- Root `typecheck` chains the new project before the recursive `pnpm -r` pass.

## The errors were real

- **`dedup-contacts.ts` was dead on arrival.** It selected `status` and `trust_level` and filtered `WHERE status IN ('confirmed','provisional')`. Both columns were dropped in migration 059 (#955/#1070), so the query fails with `column "status" does not exist` against any migrated database. Verified directly against a migrated test DB: the old query errors, the new one returns rows. The blocked-contact exclusion moves to JS via `meetsMinimumTier(tier, 'unknown')` rather than naming tiers in a `WHERE` clause.
- **`inspect-prompts.ts` / `render-coordinator-prompt.ts` read the wrong config object.** `security.trust_thresholds` lives on `YamlConfig`, not the env-derived `Config` that `loadConfig()` returns. The optional chain meant no crash, just a silent fall back to the hardcoded defaults, so a tuned threshold in `config/default.yaml` never reached the rendered prompt or the eval mock blocks. Both now use `loadYamlConfig(CONFIG_DIR)`, the same source `index.ts` uses.
- **`render-coordinator-prompt.ts` still injected `executiveVoiceBlock`.** That path and the `coordinator.yaml` placeholder were both removed in #957, so it was rendering a prompt the runtime never produces. Dropped, along with the now-unused `ExecutiveProfileService` (and its file watcher) and the display-name lookup that only fed it.
- **`spikes/voice-brain-parity/run.ts`** — the `ArmId` annotation sat on the const while `.filter()` was applied to the literal, so the arm names widened to `string`.
- **`dedup-contacts.test.ts`** — fixture carried the dropped `status`/`trustLevel`; mocks typed as `ReturnType<typeof vi.fn>` widen to `Mock<Procedure | Constructable>` and satisfy no specific call signature.

## The guard

`tests/unit/root-typecheck-coverage.test.ts` mirrors the workspace-package guard from #1726, one level up: it derives the project list from the root `typecheck` script itself and fails if any TypeScript file outside the workspace packages is in none of them.

It counts each project's **root files only**, not the transitive import closure. `scripts/seed-vault.ts` was "covered" solely because a test imports it — remove the import and it silently leaves the check, which is not coverage.

## Verification

- `pnpm run typecheck` — clean.
- Probes: a deliberate type error in `scripts/audit-verify.ts`, in `scripts/dedup-contacts.test.ts`, and in `vitest.config.ts` each produce a non-zero exit and name the file. Reverted after. Errors in `src/` still fail as before, and the workspace-package pass still runs.
- `pnpm test` — 6276 passed, 388 skipped, 0 failures.
- `pnpm run lint` — 0 errors (one pre-existing unrelated warning in `src/pii/scrubber.ts`).
- The rewritten dedup `SELECT` executed against a migrated `curia_test` DB; the old one errors on the missing column.

## Docs

The "what it does not cover" lists in CLAUDE.md and AGENTS.md drop `scripts/**` and now describe the four-project layout plus the new guard. `apps/*/vite.config.ts` stays listed as uncovered.

## Spotted, not fixed

- `scripts/**` is not linted either — ESLint ignores the whole tree (`pnpm run lint` covers `src/`, `tests/`, `apps/`). Same shape as #1727, different tree.
- `inspect-prompts.ts` still emits an `executive_voice_block` key in its JSON output, consumed by curia-deploy's eval harness. The block it describes no longer exists in any prompt, so that key is dead data — but removing it is a cross-repo contract change, not this issue's scope.