### PR TITLE
fix(deps): raise qs, hono, and fflate override floors to the patched releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Security
 
+- **Dependency pins** — `qs`, `hono`, and `fflate` raised to patched releases, clearing six advisories. (#1752)
 - **Docker image** — drop pnpm's metadata cache and store from the runtime image; they aren't used at runtime. (#1750)
 - **Docker image** — remove unused global npm so bundled brace-expansion/tar CVEs clear. (#1568)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,10 +5,10 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  hono: '>=4.12.27'
+  hono: '>=4.13.5'
   fast-uri: '>=4.1.2'
   vite: '>=8.0.5'
-  qs: '>=6.15.2'
+  qs: '>=6.16.0'
   ip-address: '>=10.1.1'
   uuid: ^11.1.1
   ws: '>=8.21.0'
@@ -26,6 +26,7 @@ overrides:
   promptfoo>js-yaml: '>=5.2.2'
   brace-expansion: '>=5.0.8'
   gaxios>rimraf: '>=6.1.2'
+  fflate: '>=0.8.3'
 
 importers:
 
@@ -1084,13 +1085,13 @@ packages:
     resolution: {integrity: sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==}
     engines: {node: '>=20'}
     peerDependencies:
-      hono: '>=4.12.27'
+      hono: '>=4.13.5'
 
   '@hono/node-server@2.1.1':
     resolution: {integrity: sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==}
     engines: {node: '>=20'}
     peerDependencies:
-      hono: '>=4.12.27'
+      hono: '>=4.13.5'
 
   '@huggingface/jinja@0.5.10':
     resolution: {integrity: sha512-SgS1D1bglQ94ceD4ZCL6eayUDy9uV1xuyk61OjgSxU5GJh7upqZCKII0JoTYMc6wWsg3JUgaPRX0ElQzXPk3Cw==}
@@ -3831,9 +3832,6 @@ packages:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
 
-  fflate@0.8.2:
-    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
-
   fflate@0.8.3:
     resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
@@ -4070,10 +4068,6 @@ packages:
 
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
-
-  hono@4.13.1:
-    resolution: {integrity: sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==}
-    engines: {node: '>=16.9.0'}
 
   hono@4.13.7:
     resolution: {integrity: sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==}
@@ -5280,10 +5274,6 @@ packages:
   python-shell@5.0.0:
     resolution: {integrity: sha512-RUOOOjHLhgR1MIQrCtnEqz/HJ1RMZBIN+REnpSUrfft2bXqXy69fwJASVziWExfFXsR1bCY0TznnHooNsCo0/w==}
     engines: {node: '>=0.10'}
-
-  qs@6.15.3:
-    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
-    engines: {node: '>=0.6'}
 
   qs@6.16.0:
     resolution: {integrity: sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==}
@@ -7204,9 +7194,9 @@ snapshots:
       graphql: 17.0.2
     optional: true
 
-  '@hono/node-server@2.1.0(hono@4.13.1)':
+  '@hono/node-server@2.1.0(hono@4.13.7)':
     dependencies:
-      hono: 4.13.1
+      hono: 4.13.7
 
   '@hono/node-server@2.1.1(hono@4.13.7)':
     dependencies:
@@ -7666,7 +7656,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.5.4)':
     dependencies:
-      '@hono/node-server': 2.1.0(hono@4.13.1)
+      '@hono/node-server': 2.1.0(hono@4.13.7)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -7676,7 +7666,7 @@ snapshots:
       eventsource-parser: 3.1.0
       express: 5.2.1
       express-rate-limit: 8.6.2(express@5.2.1)
-      hono: 4.13.1
+      hono: 4.13.7
       jose: 6.2.8
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -7942,7 +7932,7 @@ snapshots:
       ajv: 8.20.0
       extract-zip: 2.0.1
       fast-uri: 4.1.4
-      fflate: 0.8.2
+      fflate: 0.8.3
       incur: 0.4.13
       ink: 6.8.0(@types/react@19.2.18)(react@19.2.4)
       js-tiktoken: 1.0.21
@@ -9848,9 +9838,6 @@ snapshots:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
 
-  fflate@0.8.2:
-    optional: true
-
   fflate@0.8.3:
     optional: true
 
@@ -10085,7 +10072,7 @@ snapshots:
       gaxios: 7.1.3
       google-auth-library: 10.5.0
       google-logging-utils: 1.1.3
-      qs: 6.15.3
+      qs: 6.16.0
       url-template: 2.0.8
     transitivePeerDependencies:
       - supports-color
@@ -10160,8 +10147,6 @@ snapshots:
   hermes-parser@0.25.1:
     dependencies:
       hermes-estree: 0.25.1
-
-  hono@4.13.1: {}
 
   hono@4.13.7: {}
 
@@ -11587,11 +11572,6 @@ snapshots:
   punycode@2.3.1: {}
 
   python-shell@5.0.0: {}
-
-  qs@6.15.3:
-    dependencies:
-      es-define-property: 1.0.1
-      side-channel: 1.1.1
 
   qs@6.16.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -88,10 +88,21 @@ fetchTimeout: 90000
 #     that still ships a CommonJS build, which the CJS Nylas SDK requires; uuid@12+
 #     is ESM-only and would break `require('uuid')`.
 overrides:
-  hono: '>=4.12.27'
+  # Three MED GHSAs, all fixed in 4.13.5. Consumers are @hono/node-server and
+  # @modelcontextprotocol/sdk, which had both resolved 4.13.1 under the old >=4.12.27 floor:
+  #   - GHSA-crvj-82cr-hjcx: query parser reads parameters after the URL fragment
+  #     (cache-key / proxy interpretation differential)
+  #   - GHSA-g6gw-c38x-mqfc: unbounded dot-notation nesting in parseBody() exhausts memory
+  #   - GHSA-gqvv-2mrq-wpjv: toSSG() still writes outside the output dir (incomplete fix
+  #     for CVE-2026-39408)
+  hono: '>=4.13.5'
   fast-uri: '>=4.1.2'  # GHSA-7p8r-x3mc-p8w7 / CVE-2026-18446 (host confusion via backslash authority introducer, HIGH)
   vite: '>=8.0.5'
-  qs: '>=6.15.2'
+  # Two DoS advisories, both fixed in 6.16.0. The prior >=6.15.2 floor was satisfied by
+  # 6.15.3, so googleapis-common stayed on the vulnerable version:
+  #   - CVE-2026-82417 / GHSA-4mjr-xmp4-gh2g: stringify() DoS via attacker-controlled isBuffer
+  #   - CVE-2026-82562 / GHSA-x5fp-wj9c-mxmx: array-limit bypass via bracket-key comma parsing
+  qs: '>=6.16.0'
   ip-address: '>=10.1.1'
   uuid: '^11.1.1'
   # Security pins for v0.35 release gate (HIGH CVEs flagged by Trivy image scan):
@@ -117,6 +128,18 @@ overrides:
   # rimraf@6 uses glob@11+/minimatch@10 which consume brace-expansion@5; gaxios only needs
   # rimraf for temp cleanup and the v6 API is compatible for that call site.
   'gaxios>rimraf': '>=6.1.2'
+  # MED CVEs from Scorecard, 2026-09-09 (#1752):
+  fflate: '>=0.8.3'                         # GHSA-px8p-9vwx-vf98 (unzipSync infinite loop on malformed ZIP64); only consumer is @openai/codex-security via promptfoo (dev-only), which pinned 0.8.2
+  #
+  # Two Scorecard GHSAs deliberately have NO override because no fixed release exists
+  # (re-check before assuming they were missed):
+  #   - adm-zip GHSA-vwc7-r8mq-g2x9 (extraction follows destination symlinks -> arbitrary
+  #     file overwrite). Affects <=0.6.0, which is the latest publish; the >=0.6.0 pin above
+  #     is for the separate GHSA-xcpc-8h2w-3j85. Reached only via optional onnxruntime-node.
+  #   - extract-zip GHSA-7pqw-9j4j-h8q3 and GHSA-jmr9-qjv8-65gv (symlink archive entries ->
+  #     arbitrary file write). Affect <=2.0.1, the latest publish. Dev-only, via promptfoo.
+  # Both are archive-extraction bugs in dev-only paths that never process untrusted zips at
+  # runtime, so they stay as accepted Scorecard warnings until upstream ships a fix.
 
 # esbuild requires a postinstall step to download the platform binary.
 # Both versions (used by vite and tsup) are approved here.


### PR DESCRIPTION
Closes #1752.

Six advisories were open in code scanning against transitive dependencies that all have upstream fixes. Nothing exotic was going on — the existing `pnpm-workspace.yaml` override floors were just below the patched releases, so pnpm was free to keep resolving the vulnerable versions.

| Package | Before | After | Advisories cleared | Reached via |
|---|---|---|---|---|
| `qs` | 6.15.3 | 6.16.0 | CVE-2026-82417 / GHSA-4mjr-xmp4-gh2g (`stringify()` DoS via attacker-controlled `isBuffer`), CVE-2026-82562 / GHSA-x5fp-wj9c-mxmx (array-limit bypass via bracket-key comma parsing) | `googleapis-common@8.0.3` |
| `hono` | 4.13.1 | 4.13.7 | GHSA-crvj-82cr-hjcx (query parser reads past the URL fragment → cache-key/proxy differential), GHSA-g6gw-c38x-mqfc (unbounded dot-notation nesting in `parseBody()`), GHSA-gqvv-2mrq-wpjv (`toSSG()` writes outside the output dir) | `@hono/node-server`, `@modelcontextprotocol/sdk` |
| `fflate` | 0.8.2 | 0.8.3 | GHSA-px8p-9vwx-vf98 (`unzipSync` infinite loop on malformed ZIP64) | `@openai/codex-security` via `promptfoo` (dev-only) |

Notes on each:

- **`qs`** — the `>=6.15.2` floor was satisfied by 6.15.3, so `googleapis-common` was never re-resolved.
- **`hono`** — all three are fixed in 4.13.5; the `>=4.12.27` floor left both consumers on 4.13.1. The tree already carried a clean 4.13.7 for the other consumer, so this collapses two copies into one.
- **`fflate`** — had no override at all, and the tree already carried a clean 0.8.3 beside the vulnerable 0.8.2.

## Deliberate omissions

Two of the nine GHSAs in Scorecard alert #155 get **no** override because no fixed release has been published. Both are archive-extraction bugs on dev-only paths that never process untrusted archives:

- `adm-zip` GHSA-vwc7-r8mq-g2x9 — affects `<=0.6.0`, which is the latest publish. (The existing `>=0.6.0` pin is for the unrelated GHSA-xcpc-8h2w-3j85.) Reached via optional `onnxruntime-node`.
- `extract-zip` GHSA-7pqw-9j4j-h8q3 and GHSA-jmr9-qjv8-65gv — affect `<=2.0.1`, the latest publish. Dev-only, via `promptfoo`.

Both are now recorded in `pnpm-workspace.yaml` with the reason, so the next person reads them as a decision rather than an oversight. Alert #155 should therefore drop from 9 vulnerabilities to 3, not to 0.

## Verification

- `pnpm install --frozen-lockfile` — passes, so the lockfile satisfies `minimumReleaseAge` and `trustPolicy` and won't block CI or the production image build.
- `pnpm typecheck` — clean across root, skills, tests, scripts, and all three workspace packages.
- `pnpm test` — 6366 passed, 0 failed (388 skipped; 62 integration files skipped without a database).
- Lockfile grep confirms no residual `qs@6.15.x`, `hono@4.13.1`, or `fflate@0.8.2`.
