### PR TITLE
fix(ci): honour nosemgrep suppressions by filtering them out of the SARIF

### DIFF
--- a/.github/scripts/filter-suppressed-sarif.py
+++ b/.github/scripts/filter-suppressed-sarif.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Drop already-suppressed results from a SARIF file, in place.
+
+GitHub code scanning ignores SARIF ``suppressions``. Semgrep honours an in-tree
+``# nosemgrep`` comment — it excludes the finding from its console output and emits it
+with ``"suppressions": [{"state": "accepted"}]`` — but ``upload-sarif`` surfaces it as an
+OPEN alert regardless. Every deliberately-accepted finding therefore has to be dismissed
+by hand in the Security tab, and that dismissal is keyed to the finding's fingerprint: edit
+a comment near the suppressed line and the alert comes back as a fresh, undismissed one.
+That is exactly how alert #192 returned as #262 on ``pnpm-workspace.yaml``.
+
+Running this between the scan and the upload makes the ``# nosemgrep`` comment the single
+source of truth for what is accepted — in the tree, in code review, next to the reason —
+instead of a click in a web UI that silently evaporates. It does not decide anything on its
+own: the scanner has already classified these findings as suppressed, and this only forwards
+that classification to a consumer that would otherwise discard it.
+
+Nothing is dropped quietly. Every removed finding is printed with its rule ID and location.
+
+Fail closed. A missing, unparseable, or non-SARIF input exits non-zero so the workflow step
+fails loudly. Exiting 0 on a broken file would hand a stale or truncated SARIF to
+``upload-sarif``, which reads "no findings" as "everything was fixed" and would close real
+alerts across the repo.
+
+Usage: filter-suppressed-sarif.py <path-to-sarif>
+"""
+
+import json
+import sys
+
+
+def is_suppressed(result):
+    """True when the scanner marked this result suppressed.
+
+    Semgrep writes ``"suppressions": []`` on findings it did NOT suppress, so the emptiness
+    of the list is the signal, not the presence of the key. Treating the key as a boolean
+    would delete every finding in the file.
+    """
+    return bool(result.get("suppressions"))
+
+
+def describe(result):
+    """A short human-readable identifier for the job log."""
+    rule = result.get("ruleId", "<no ruleId>")
+    locations = result.get("locations") or []
+    if not locations:
+        return rule
+    physical = locations[0].get("physicalLocation", {})
+    uri = physical.get("artifactLocation", {}).get("uri", "<no file>")
+    line = physical.get("region", {}).get("startLine")
+    return "{} at {}{}".format(rule, uri, ":{}".format(line) if line else "")
+
+
+def main(argv):
+    if len(argv) != 2:
+        print("usage: filter-suppressed-sarif.py <path-to-sarif>", file=sys.stderr)
+        return 1
+
+    path = argv[1]
+
+    try:
+        with open(path, encoding="utf-8") as handle:
+            sarif = json.load(handle)
+    except OSError as err:
+        print("cannot read SARIF file {}: {}".format(path, err), file=sys.stderr)
+        return 1
+    except ValueError as err:
+        print("{} is not valid JSON: {}".format(path, err), file=sys.stderr)
+        return 1
+
+    runs = sarif.get("runs") if isinstance(sarif, dict) else None
+    if not isinstance(runs, list):
+        print("{} has no 'runs' array — not a SARIF document".format(path), file=sys.stderr)
+        return 1
+
+    dropped = []
+    for run in runs:
+        results = run.get("results")
+        if not isinstance(results, list):
+            # A run may legitimately omit `results`; nothing to filter there.
+            continue
+        kept = [r for r in results if not is_suppressed(r)]
+        dropped.extend(r for r in results if is_suppressed(r))
+        run["results"] = kept
+
+    if not dropped:
+        # Leave the file untouched rather than round-tripping it through the JSON encoder,
+        # so the common case uploads exactly the bytes the scanner produced.
+        print("no suppressed findings in {}; SARIF left unchanged".format(path))
+        return 0
+
+    for result in dropped:
+        print("dropping suppressed finding: {}".format(describe(result)))
+
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump(sarif, handle)
+
+    print("dropped {} suppressed finding(s) from {}".format(len(dropped), path))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.github/scripts/filter-suppressed-sarif.py
+++ b/.github/scripts/filter-suppressed-sarif.py
@@ -18,9 +18,9 @@ that classification to a consumer that would otherwise discard it.
 Nothing is dropped quietly. Every removed finding is printed with its rule ID and location.
 
 Fail closed. A missing, unparseable, or non-SARIF input exits non-zero so the workflow step
-fails loudly. Exiting 0 on a broken file would hand a stale or truncated SARIF to
-``upload-sarif``, which reads "no findings" as "everything was fixed" and would close real
-alerts across the repo.
+fails loudly -- including the sharpest case, a document that parses cleanly but carries zero
+runs. Exiting 0 on any of those would hand a stale or degenerate SARIF to ``upload-sarif``,
+which reads a missing finding as a FIXED finding and would close real alerts across the repo.
 
 Usage: filter-suppressed-sarif.py <path-to-sarif>
 """
@@ -68,10 +68,45 @@ def main(argv):
         print("{} is not valid JSON: {}".format(path, err), file=sys.stderr)
         return 1
 
-    runs = sarif.get("runs") if isinstance(sarif, dict) else None
+    # Validate the document before touching it. A `runs` list alone does not make
+    # something SARIF, and the cost of getting this wrong is asymmetric: a file that
+    # parses but is not a real scan result gets forwarded to upload-sarif, which reads a
+    # missing finding as a FIXED finding and closes real alerts across the repo. Every
+    # check below therefore rejects rather than repairs.
+    if not isinstance(sarif, dict):
+        print("{} is not a JSON object — not a SARIF document".format(path), file=sys.stderr)
+        return 1
+
+    # `version` is required on the root sarifLog (SARIF 2.1.0 §3.13). Its exact value is
+    # deliberately NOT pinned: upload-sarif rejects a revision it cannot consume on its
+    # own, loudly, whereas pinning "2.1.0" here would hard-fail this job the day Semgrep
+    # starts emitting a newer one. Presence is the signal that this came from a scanner.
+    if not sarif.get("version"):
+        print("{} has no 'version' — not a SARIF document".format(path), file=sys.stderr)
+        return 1
+
+    runs = sarif.get("runs")
     if not isinstance(runs, list):
         print("{} has no 'runs' array — not a SARIF document".format(path), file=sys.stderr)
         return 1
+
+    # Zero runs is the shape that would do the most damage, because it is structurally
+    # valid and semantically catastrophic. Semgrep never emits it: a scan that found
+    # nothing is ONE run carrying an empty `results` array (verified against
+    # `semgrep --sarif` over a file with no findings). Zero runs therefore means
+    # something went wrong upstream, and forwarding it would tell GitHub that every
+    # open alert in the repo has been fixed.
+    if not runs:
+        print("{} carries zero runs — refusing to forward it as a clean scan".format(path),
+              file=sys.stderr)
+        return 1
+
+    for index, run in enumerate(runs):
+        # `tool` is required on every run (SARIF 2.1.0 §3.14).
+        if not isinstance(run, dict) or "tool" not in run:
+            print("{} run[{}] is not a SARIF run object (no 'tool')".format(path, index),
+                  file=sys.stderr)
+            return 1
 
     dropped = []
     for run in runs:

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -47,6 +47,28 @@ jobs:
             --exclude 'pnpm-lock.yaml' \
             --exclude 'tests/**/*.snap'
 
+      # GitHub code scanning ignores SARIF `suppressions`. Semgrep honours an in-tree
+      # `# nosemgrep` comment — it drops the finding from its console output and emits it
+      # with `"suppressions": [{"state": "accepted"}]` — but upload-sarif surfaces it as an
+      # OPEN alert anyway. Every deliberately-accepted finding then has to be dismissed by
+      # hand in the Security tab, and that dismissal is keyed to the finding's fingerprint:
+      # editing a comment near the suppressed line resurrects it as a fresh, undismissed
+      # alert. Alert #192 came back as #262 on pnpm-workspace.yaml exactly that way, with
+      # the `# nosemgrep` comment sitting right above the line the whole time.
+      #
+      # Filtering here makes that comment the single source of truth for what is accepted:
+      # in the tree, in code review, next to the reason it was accepted. The step decides
+      # nothing on its own — Semgrep already classified these findings as suppressed, and
+      # this only forwards that classification to a consumer that would otherwise discard
+      # it. Each dropped finding is named in the job log.
+      #
+      # Deliberately NOT continue-on-error: a missing or malformed SARIF must fail the job.
+      # upload-sarif reads an empty result set as "everything was fixed" and would close
+      # real alerts across the repo.
+      - name: Drop nosemgrep-suppressed findings before upload
+        if: always()
+        run: python3 .github/scripts/filter-suppressed-sarif.py semgrep.sarif
+
       - name: Upload SARIF
         uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Security
 
+- **Semgrep SARIF** — `# nosemgrep`-suppressed findings no longer upload as open code-scanning alerts. (#1754)
 - **Dependency pins** — `qs`, `hono`, and `fflate` raised to patched releases, clearing six advisories. (#1752)
 - **Docker image** — drop pnpm's metadata cache and store from the runtime image; they aren't used at runtime. (#1750)
 - **Docker image** — remove unused global npm so bundled brace-expansion/tar CVEs clear. (#1568)

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build": "tsup src/index.ts --format esm --dts",
     "start": "node dist/index.js",
     "test": "vitest run",
-    "test:shell": "bash tests/setup/test-setup-functions.sh && bash tests/docker/test-pnpm-retry.sh",
+    "test:shell": "bash tests/setup/test-setup-functions.sh && bash tests/docker/test-pnpm-retry.sh && bash tests/ci/test-filter-suppressed-sarif.sh",
     "test:postgres-image": "bash tests/docker/test-postgres-init.sh",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.skills.json && tsc --noEmit -p tsconfig.tests.json && tsc --noEmit -p tsconfig.scripts.json && pnpm -r run typecheck",

--- a/tests/ci/test-filter-suppressed-sarif.sh
+++ b/tests/ci/test-filter-suppressed-sarif.sh
@@ -125,6 +125,47 @@ check_eq "fails on JSON that is not SARIF (no runs)" "1" "$?"
 python3 "$SCRIPT" >/dev/null 2>&1
 check_eq "fails when given no path" "1" "$?"
 
+# `runs` being a list is not enough to call a document SARIF. `version` is required on
+# the root sarifLog and `tool` is required on every run (SARIF 2.1.0 §3.13, §3.14), so a
+# document missing either is something other than a scanner result — most likely a stub
+# or a half-written file — and must not be forwarded as if it were a clean scan.
+printf '{"runs":[{"tool":{"driver":{"name":"x"}},"results":[]}]}' > "$tmpdir/noversion.sarif"
+python3 "$SCRIPT" "$tmpdir/noversion.sarif" >/dev/null 2>&1
+check_eq "fails on a document with no 'version'" "1" "$?"
+
+printf '{"version":"2.1.0","runs":[{"results":[]}]}' > "$tmpdir/notool.sarif"
+python3 "$SCRIPT" "$tmpdir/notool.sarif" >/dev/null 2>&1
+check_eq "fails on a run with no 'tool'" "1" "$?"
+
+printf '{"version":"2.1.0","runs":["not-an-object"]}' > "$tmpdir/badrun.sarif"
+python3 "$SCRIPT" "$tmpdir/badrun.sarif" >/dev/null 2>&1
+check_eq "fails on a run that is not an object" "1" "$?"
+
+# The shape that would do the most damage: structurally valid SARIF carrying no runs at
+# all. Semgrep never emits this — a clean scan is ONE run with an empty `results` array
+# (verified against `semgrep --sarif` on a file with no findings) — so zero runs means
+# something went wrong upstream. upload-sarif would read it as "every finding is fixed"
+# and close real alerts across the repo.
+printf '{"version":"2.1.0","runs":[]}' > "$tmpdir/noruns-array.sarif"
+python3 "$SCRIPT" "$tmpdir/noruns-array.sarif" >/dev/null 2>&1
+check_eq "fails on valid SARIF carrying zero runs" "1" "$?"
+
+# --- the strictness must not reject a legitimately clean scan ---------------------
+# A scan that found nothing is one run, with `tool`, and an empty `results` array. This
+# is the single most common real input; failing it would break every green Semgrep run.
+f="$tmpdir/cleanscan.sarif"
+write_sarif "$f" "[]"
+python3 "$SCRIPT" "$f" >/dev/null 2>&1
+check_eq "accepts a clean scan (one run, empty results)" "0" "$?"
+
+# `version` is required to be PRESENT, but its exact value is deliberately not pinned:
+# upload-sarif rejects a version it cannot consume on its own, loudly, whereas pinning
+# here would hard-fail the job the day Semgrep emits a newer SARIF revision.
+printf '{"version":"2.2.0","runs":[{"tool":{"driver":{"name":"x"}},"results":[]}]}' \
+  > "$tmpdir/future.sarif"
+python3 "$SCRIPT" "$tmpdir/future.sarif" >/dev/null 2>&1
+check_eq "accepts a future SARIF version rather than pinning 2.1.0" "0" "$?"
+
 echo
 printf '%d passed, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/tests/ci/test-filter-suppressed-sarif.sh
+++ b/tests/ci/test-filter-suppressed-sarif.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Tests for .github/scripts/filter-suppressed-sarif.py (curia#1754).
+#
+# Why the script exists: GitHub code scanning ignores SARIF `suppressions`. Semgrep
+# honours an in-tree `# nosemgrep` comment and emits the finding with
+# `"suppressions": [{"state": "accepted"}]`, but GitHub uploads it as an OPEN alert
+# anyway, so every suppressed finding has to be hand-dismissed in the UI. That
+# dismissal is keyed to the finding's fingerprint, so editing a comment near the
+# suppressed line resurrects it as a fresh, undismissed alert — which is exactly how
+# alert #192 came back as #262 on pnpm-workspace.yaml.
+#
+# The script drops already-suppressed results before upload so the `# nosemgrep`
+# comment is the single reviewable source of truth. These tests pin the behaviour
+# that matters: unsuppressed findings must survive untouched, and a malformed or
+# missing SARIF must fail loudly rather than silently uploading nothing.
+#
+# Run: bash tests/ci/test-filter-suppressed-sarif.sh
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$REPO_ROOT/.github/scripts/filter-suppressed-sarif.py"
+
+pass=0
+fail=0
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+ok()  { printf '  ok   %s\n' "$1"; pass=$((pass + 1)); }
+bad() { printf '  FAIL %s\n' "$1"; fail=$((fail + 1)); }
+
+check_eq() { # label expected actual
+  if [ "$2" = "$3" ]; then ok "$1"; else bad "$1 (expected '$2', got '$3')"; fi
+}
+
+# Build a SARIF file with one run whose results are the given JSON array literal.
+write_sarif() { # path results_json
+  cat > "$1" <<JSON
+{
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": { "driver": { "name": "Semgrep OSS" } },
+      "results": $2
+    }
+  ]
+}
+JSON
+}
+
+SUPPRESSED='{"ruleId":"r.suppressed","suppressions":[{"kind":"inSource","state":"accepted"}],
+  "locations":[{"physicalLocation":{"artifactLocation":{"uri":"pnpm-workspace.yaml"},
+  "region":{"startLine":50}}}]}'
+LIVE='{"ruleId":"r.live",
+  "locations":[{"physicalLocation":{"artifactLocation":{"uri":"src/a.ts"},
+  "region":{"startLine":7}}}]}'
+# Semgrep emits `"suppressions": []` for a finding it did NOT suppress. An empty
+# array must be treated as "not suppressed" — reading it as truthy would delete
+# every real finding in the file.
+EMPTY_SUPP='{"ruleId":"r.empty-array",
+  "suppressions":[],
+  "locations":[{"physicalLocation":{"artifactLocation":{"uri":"src/b.ts"},
+  "region":{"startLine":9}}}]}'
+
+results_of() { # sarif_path -> newline-separated ruleIds
+  python3 -c 'import json,sys
+d=json.load(open(sys.argv[1]))
+print("\n".join(r.get("ruleId","") for run in d["runs"] for r in run["results"]))' "$1"
+}
+
+echo "filter-suppressed-sarif"
+
+# --- drops suppressed, keeps everything else ------------------------------------
+f="$tmpdir/mixed.sarif"
+write_sarif "$f" "[$SUPPRESSED, $LIVE, $EMPTY_SUPP]"
+out="$(python3 "$SCRIPT" "$f" 2>&1)"
+check_eq "exits 0 on a well-formed SARIF" "0" "$?"
+check_eq "keeps the unsuppressed results" "r.live
+r.empty-array" "$(results_of "$f")"
+if printf '%s' "$out" | grep -q "pnpm-workspace.yaml:50"; then
+  ok "names each dropped finding in its output"
+else
+  bad "names each dropped finding in its output (got: $out)"
+fi
+
+# --- a file with nothing suppressed is left exactly as-is ------------------------
+f="$tmpdir/clean.sarif"
+write_sarif "$f" "[$LIVE]"
+before="$(cat "$f")"
+python3 "$SCRIPT" "$f" >/dev/null 2>&1
+check_eq "leaves a SARIF with no suppressions byte-identical" "$before" "$(cat "$f")"
+
+# --- every result suppressed -> valid empty-results SARIF, still exit 0 ----------
+f="$tmpdir/all.sarif"
+write_sarif "$f" "[$SUPPRESSED]"
+python3 "$SCRIPT" "$f" >/dev/null 2>&1
+check_eq "exits 0 when every result is suppressed" "0" "$?"
+check_eq "leaves an empty results array, not a broken file" "" "$(results_of "$f")"
+
+# --- multiple runs are each filtered independently -------------------------------
+f="$tmpdir/multirun.sarif"
+cat > "$f" <<JSON
+{"version":"2.1.0","runs":[
+  {"tool":{"driver":{"name":"a"}},"results":[$SUPPRESSED,$LIVE]},
+  {"tool":{"driver":{"name":"b"}},"results":[$LIVE]}
+]}
+JSON
+python3 "$SCRIPT" "$f" >/dev/null 2>&1
+check_eq "filters every run, not just the first" "r.live
+r.live" "$(results_of "$f")"
+
+# --- fail closed -----------------------------------------------------------------
+# A missing, unparseable, or non-SARIF file must fail the step. Exiting 0 here would
+# hand a truncated or stale SARIF to upload-sarif and quietly shrink the Security tab.
+python3 "$SCRIPT" "$tmpdir/does-not-exist.sarif" >/dev/null 2>&1
+check_eq "fails on a missing file" "1" "$?"
+
+printf 'not json at all' > "$tmpdir/bad.sarif"
+python3 "$SCRIPT" "$tmpdir/bad.sarif" >/dev/null 2>&1
+check_eq "fails on unparseable JSON" "1" "$?"
+
+printf '{"version":"2.1.0"}' > "$tmpdir/noruns.sarif"
+python3 "$SCRIPT" "$tmpdir/noruns.sarif" >/dev/null 2>&1
+check_eq "fails on JSON that is not SARIF (no runs)" "1" "$?"
+
+python3 "$SCRIPT" >/dev/null 2>&1
+check_eq "fails when given no path" "1" "$?"
+
+echo
+printf '%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
Closes #1754.

GitHub code scanning ignores SARIF `suppressions`, so an in-tree `# nosemgrep` comment does not keep a finding out of the Security tab.

Semgrep itself honours the comment — verified locally against `pnpm-workspace.yaml`:

```
$ semgrep --config p/owasp-top-ten --disable-nosem pnpm-workspace.yaml
package_managers.pnpm.pnpm-missing-minimum-release-age.pnpm-minimum-release-age L50

$ semgrep --config p/owasp-top-ten pnpm-workspace.yaml
(0 findings)
```

But the uploaded SARIF still carries the finding, tagged `"suppressions": [{"state": "accepted"}]`, and `upload-sarif` turns it into an **open** alert. All five results in the latest Semgrep analysis on `main` are suppressed, and each maps to an in-tree `# nosemgrep` comment on the line above:

| Rule | Location | `# nosemgrep` at |
|---|---|---|
| `pnpm-minimum-release-age` | `pnpm-workspace.yaml:50` | line 49 |
| `missing-user-entrypoint` | `docker/postgres.Dockerfile:42` | line 41 |
| `missing-user` | `docker/postgres.Dockerfile:51` | line 50 |
| `direct-response-write` | `src/channels/http/routes/antfarm-assets.ts:86` | line 85 |
| `gcm-no-tag-length` | `src/secrets/crypto.ts:43` | line 42 |

Every one had to be dismissed by hand — and the dismissal does not stick, because it is keyed to the finding's fingerprint. Editing a comment near the suppressed line resurrects it as a fresh, undismissed alert: **#190 → #192 → #262**, same rule, same line, with the `# nosemgrep` comment sitting above it the whole time. Alert #262 is open right now for exactly that reason. The other four carry the same latent churn.

## The fix

Filter suppressed results out of the SARIF between the scan and the upload, so the `# nosemgrep` comment becomes the single source of truth for what is accepted — in the tree, next to the reason, reviewable in a PR — instead of a click in a web UI that silently evaporates.

The step decides nothing on its own. Semgrep has already classified these findings as suppressed; the filter only forwards that classification to a consumer that would otherwise discard it. Each dropped finding is named in the job log, so nothing disappears quietly.

It is **fail-closed and deliberately not `continue-on-error`**: a missing, unparseable, or non-SARIF input fails the job. `upload-sarif` reads an empty result set as "everything was fixed" and would use it to close real alerts across the repo — the worst possible failure mode for a step that touches the Security tab.

## Verification

Run against the real SARIF pulled from the latest `main` analysis:

```
dropping suppressed finding: dockerfile.security.missing-user-entrypoint... at docker/postgres.Dockerfile:42
dropping suppressed finding: dockerfile.security.missing-user... at docker/postgres.Dockerfile:51
dropping suppressed finding: package_managers.pnpm...pnpm-minimum-release-age at pnpm-workspace.yaml:50
dropping suppressed finding: javascript.express.security.audit.xss.direct-response-write... at src/channels/http/routes/antfarm-assets.ts:86
dropping suppressed finding: javascript.node-crypto.security.gcm-no-tag-length... at src/secrets/crypto.ts:43
dropped 5 suppressed finding(s)
```

Exactly the five findings with in-tree `# nosemgrep` comments, and nothing else.

`tests/ci/test-filter-suppressed-sarif.sh` — 11 assertions, wired into `pnpm test:shell` so CI runs it. Written before the script (all 11 failed first). The one that matters most: `"suppressions": []` is Semgrep's marker for a finding it did **not** suppress, so reading the key as a boolean would delete every real finding in the file.

```
filter-suppressed-sarif
  ok   exits 0 on a well-formed SARIF
  ok   keeps the unsuppressed results
  ok   names each dropped finding in its output
  ok   leaves a SARIF with no suppressions byte-identical
  ok   exits 0 when every result is suppressed
  ok   leaves an empty results array, not a broken file
  ok   filters every run, not just the first
  ok   fails on a missing file
  ok   fails on unparseable JSON
  ok   fails on JSON that is not SARIF (no runs)
  ok   fails when given no path

11 passed, 0 failed
```

The Semgrep job on this PR exercises the step end-to-end inside the `semgrep/semgrep` container.

## Noted in passing, not changed

`.github/workflows/semgrep.yml`'s `actions/checkout` is the only one in the repo without `persist-credentials: false`. Out of scope here.
