### PR TITLE
fix(docker): keep pnpm's store in the runtime image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Security
 
+- **Docker image** — keep pnpm's store; removing it made the deploy build re-download every package. (#1756)
 - **Semgrep SARIF** — `# nosemgrep`-suppressed findings no longer upload as open code-scanning alerts. (#1754)
 - **Dependency pins** — `qs`, `hono`, and `fflate` raised to patched releases, clearing six advisories. (#1752)
 - **Docker image** — drop pnpm's metadata cache and store from the runtime image; they aren't used at runtime. (#1750)

--- a/Dockerfile
+++ b/Dockerfile
@@ -162,9 +162,6 @@ COPY docker/pnpm-retry.sh /usr/local/bin/pnpm-retry
 #     `createTokenAuth("ghp_…")` documentation snippet alone produced twelve CRITICAL
 #     github-pat / github-app-token findings (code-scanning #271-#282). False positives,
 #     but they were the only CRITICALs in the Security tab and buried everything else.
-#   - /root/.local/share/pnpm — the content-addressable store and pnpm's global bin dir.
-#     node_modules entries are hardlinks INTO the store, so unlinking the store paths
-#     leaves those inodes referenced by node_modules; the installed tree is untouched.
 #   - /root/.cache/node/corepack and /root/.cache/corepack — corepack's cached pnpm
 #     tarballs. Node 24's bundled corepack pre-caches pnpm@11.0.8 during `corepack
 #     enable` even though this project pins pnpm@11.7.0, and 11.0.8 bundles tar@7.5.13
@@ -176,6 +173,20 @@ COPY docker/pnpm-retry.sh /usr/local/bin/pnpm-retry
 # None of it is reachable at runtime: CMD invokes ./node_modules/.bin/tsx directly and
 # no install ever runs inside the container.
 #
+# What is deliberately KEPT: /root/.local/share/pnpm, the content-addressable store.
+# An earlier revision of this step deleted it too. That was wrong, and it broke the
+# deploy. curia-deploy's thin downstream image (deploy/compose/Dockerfile.curia) builds
+# FROM this one, switches to root, and runs `pnpm add` with an inline HOME=/root
+# specifically so pnpm resolves the store to /root/.local/share/pnpm/store/v11 — the
+# path THIS stage creates. Removing it left that build with an empty store, so every
+# tarball was re-downloaded ("reused 0") instead of hardlinked, turning a deploy into a
+# full re-fetch of the dependency graph against a flaky registry.
+#
+# Keeping the store costs nothing here. All twelve secret findings were in the metadata
+# cache above (/root/.cache/pnpm/v11/metadata-full/*.jsonl); not one was in the store,
+# which shipped in this image for its whole history without ever tripping a Trivy rule.
+# The store holds content-addressed blobs, not per-package README text.
+#
 # Why one RUN. Deleting these in a LATER layer is not enough. Trivy's secret scanner
 # reports matches from any layer in the image, not just the whiteout-applied final
 # filesystem — which is the correct stance, since the content is still extractable from
@@ -186,16 +197,15 @@ COPY docker/pnpm-retry.sh /usr/local/bin/pnpm-retry
 # which is why the earlier later-layer corepack cleanup did clear its tar CVE.)
 #
 # Fail closed. `rm -rf` exits 0 whether or not it removed anything, so a future pnpm or
-# base-image change that relocated the store would silently turn this into a no-op — or,
-# worse, a store layout that COPIED instead of hardlinking would leave a broken tsx
-# behind a green build. Executing tsx after the removal proves the runtime entry point
-# still resolves, which is the one property this cleanup must not break. This mirrors
-# the assertions around the npm/npx removal above.
+# base-image change that relocated any of these paths would silently turn this into a
+# no-op while the build stayed green. Executing tsx afterwards proves the runtime entry
+# point still resolves — the one property this cleanup must not break — and mirrors the
+# assertions around the npm/npx removal above.
 RUN set -e; \
     pnpm-retry pnpm install --frozen-lockfile --prod; \
     pnpm-retry pnpm add -w --save-prod --prod tsx; \
     rm -rf /root/.cache/node/corepack /root/.cache/corepack \
-           /root/.cache/pnpm /root/.local/share/pnpm \
+           /root/.cache/pnpm \
            /usr/local/bin/pnpm-retry; \
     ./node_modules/.bin/tsx --version
 


### PR DESCRIPTION
Closes #1756. Fixes a deploy regression I introduced in #1750/#1751.

#1750 removed pnpm's metadata cache **and** its content-addressable store from the runtime image. Removing the store was a mistake.

`curia-deploy`'s thin downstream image (`deploy/compose/Dockerfile.curia`) builds `FROM ghcr.io/josephfung/curia:edge`, switches to root, and runs `pnpm add` with an inline `HOME=/root` for the express purpose of resolving the store to `/root/.local/share/pnpm/store/v11` — the path this stage creates. Its own comment says so:

> the core image built its node_modules as root with the default `HOME=/root`, so the store actually lives at `/root/.local/share/pnpm/store/v11`

Deleting it left that build with an empty store and a cold metadata cache. Since `pnpm add` forces a strict full-workspace re-resolution (the same behaviour that makes `-w --prod --save-prod` necessary here), a deploy turned into a full re-fetch of the dependency graph:

```
Progress: resolved 378, reused 0, downloaded 0, added 0
[WARN] Request took 1530710ms: https://registry.npmjs.org/@opencode-ai%2Fsdk
[WARN] GET https://registry.npmjs.org/drizzle-orm error (23). Will retry in 10 seconds.
[WARN] GET https://registry.npmjs.org/drizzle-orm error (UND_ERR_SOCKET). Will retry in 10 seconds.
[WARN] GET https://registry.npmjs.org/@opencode-ai%2Fsdk error (ECONNRESET). Will retry in 10 seconds.
```

- **`reused 0`** — the empty store. With a populated one pnpm reports a non-zero reuse count.
- **`@opencode-ai/sdk`** is a `promptfoo` transitive, i.e. a **devDependency** — the downstream was pulling packuments for the entire workspace graph.

To be fair about causation: the `ECONNRESET` / `UND_ERR_SOCKET` / `error (23)` failures are ordinary registry flakiness and were not introduced here. What changed is *exposure* — a build that touched the registry lightly now pulls the whole graph, so it is far likelier to land on a bad connection. And the cost is permanent, not a cold start: every downstream rebuild from a new `:edge` pays it.

## The security fix is unaffected

All twelve `github-pat` / `github-app-token` findings (#271–#282) were in the **metadata** cache, `/root/.cache/pnpm/v11/metadata-full/*.jsonl` — the per-package JSONL files that embed README text, including `@octokit/auth-token`'s `createTokenAuth("ghp_…")` snippet.

**None were in the store.** It shipped in this image for its entire history without ever tripping a Trivy rule; it holds content-addressed blobs, not README prose. Deleting the metadata cache was the whole win. Deleting the store was pure cost.

So this keeps the store and continues to delete the metadata cache inside the same single layer. The comment now records the downstream coupling explicitly, so it doesn't get deleted again as "unused build residue" — which is exactly how I got here.

## Verification

- [ ] Dispatched Trivy image scan on this branch still reports **zero** `github-pat` / `github-app-token` findings.
- [ ] The build's `tsx --version` assertion still passes.

## Follow-up, not in this PR

The downstream image has no `pnpm-retry` wrapper — this stage deletes it as build-only tooling (#1699), so `Dockerfile.curia` runs a bare `pnpm add` and a single unhandled socket abort kills the deploy outright. Worth fixing on the `curia-deploy` side.

Longer term, the deeper issue is that adding one package downstream forces a re-resolution of the entire workspace. That is the thing actually making deploys network-heavy; the warm store only hides it.
