### PR TITLE
feat(health): probe the Signal voice audio socket in /api/health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
+- **`signal_voice` health check** — `/api/health` now probes the Signal call audio socket by connecting, not stat'ing. (#1760)
 - **Auto-generated mail detection** — classifies inbound email from message signals and suppresses replies at dispatch. (#1734)
 - **`apps/*` lint coverage** — ESLint now checks console and antfarm; `no-console` stays backend-only. (#1727)
 - **React hooks linting** — `rules-of-hooks` and `exhaustive-deps` now gate the browser apps. (#1727)

--- a/apps/console/src/pages/dashboard/dashboard-utils.test.ts
+++ b/apps/console/src/pages/dashboard/dashboard-utils.test.ts
@@ -60,6 +60,24 @@ describe('formatUptime', () => {
 });
 
 describe('flattenHealthChecks', () => {
+  // #1760 relies on this being fully dynamic: a check added to /api/health must render
+  // as a chip with NO console change. During curia-deploy#221 the dashboard showed
+  // "All systems nominal" while Signal voice audio was dead, and the backend fix was a
+  // new `signal_voice` check. If this function (or HealthResponse['checks']) is ever
+  // narrowed to a fixed key set, that contract breaks silently — the backend reports a
+  // failure the operator never sees. This test is the tripwire.
+  it('renders a chip for a check key it has never seen before (#1760)', () => {
+    const pills = flattenHealthChecks({
+      db: 'ok',
+      signal: 'ok',
+      voice: 'ok',
+      signal_voice: 'fail',
+    });
+    expect(pills).toContainEqual({ name: 'signal_voice', result: 'fail' });
+    // And the failing one must be visually distinct, not merely present.
+    expect(healthCheckPillClass('fail')).toBe('blocked');
+  });
+
   it('flattens top-level checks and expands nested mcp.*', () => {
     const pills = flattenHealthChecks({
       db: 'ok',

--- a/src/channels/http/routes/health.ts
+++ b/src/channels/http/routes/health.ts
@@ -45,6 +45,7 @@ export async function healthRoutes(
           slack: 'skipped' as const,
           sms: 'skipped' as const,
           voice: 'skipped' as const,
+          signal_voice: 'skipped' as const,
           scheduler: 'fail' as const,
         },
       });

--- a/src/health/health-checks.ts
+++ b/src/health/health-checks.ts
@@ -2,10 +2,12 @@
 //
 // Each function is independent, has a hard timeout for async probes, and returns
 // CheckResult. 'skipped' means the service is not configured — never affects the
-// overall health status. Probe-based checks (db, bus, signal, browser, mcp) run
+// overall health status. Probe-based checks (db, bus, signal, signal_voice, browser,
+// mcp) run
 // on every request. Time-based checks (email, scheduler) use startedAt as a
 // grace-period anchor so they don't fail immediately at boot.
 
+import { connect as netConnect } from 'node:net';
 import type { Pool } from 'pg';
 import type { EventBus } from '../bus/bus.js';
 import type { CheckResult } from './types.js';
@@ -352,6 +354,76 @@ export async function checkVoice(
     logger.warn({ err }, 'checkVoice: LiveKit management probe failed');
     return 'fail';
   }
+}
+
+/** Default budget for the Signal-voice socket probe. Local Unix socket — connect is
+ * either immediate or the daemon is not there. */
+export const SIGNAL_VOICE_PROBE_TIMEOUT_MS = 2_000;
+
+/**
+ * Signal voice audio path liveness (#1760). Non-critical.
+ *
+ * Distinct from both neighbours, which is the whole point of it existing:
+ *   - `signal` probes the JSON-RPC socket  → Signal MESSAGING
+ *   - `voice` probes LiveKit `listRooms()` → console / WebRTC voice
+ *   - this probes the shared PulseAudio socket → Signal voice CALLS
+ *
+ * During curia-deploy#221 the PulseAudio daemon failed to start for hours (a stale
+ * pid file made it believe one was already running). Signal calls could not carry
+ * audio, and `/api/health` reported everything ok because nothing covered this path.
+ *
+ * Probes by CONNECTING, not by stat'ing. `existsSync` / `test -S` cannot tell a live
+ * daemon from a corpse: the #221 container held a socket inode written by a daemon
+ * that had been dead for a week. A connect gets ECONNREFUSED against that inode and
+ * succeeds only when something is actually accepting.
+ *
+ * No PulseAudio protocol handshake is attempted. "Something is accepting on the
+ * socket the call bridge was configured to use" is the property worth asserting;
+ * anything deeper couples a liveness endpoint to a wire format that is not ours.
+ *
+ * Known tradeoff: connecting and closing without a handshake may make PulseAudio log a
+ * short-lived client on each probe, and the Docker healthcheck hits /api/health every
+ * 30s. Accepted deliberately — a handshake-free connect cannot desync from a protocol
+ * change, and the alternative (stat) is what let a dead daemon read as healthy. If that
+ * log noise ever obscures debugging, raise the probe interval rather than weaken it
+ * back to an existence check.
+ *
+ * `skipped` when no path is given — the Signal call bridge was not constructed, so
+ * there is nothing to be unhealthy about. Matches `checkVoice`'s convention.
+ */
+export async function checkSignalVoice(
+  pulseSocketPath: string | undefined,
+  logger: Logger,
+  timeoutMs: number = SIGNAL_VOICE_PROBE_TIMEOUT_MS,
+): Promise<CheckResult> {
+  if (!pulseSocketPath) return 'skipped';
+
+  return new Promise<CheckResult>((resolve) => {
+    // settle() guarantees exactly one resolve and exactly one destroy, whichever of
+    // connect / error / timeout fires first. A probe that leaks a socket per call
+    // would exhaust descriptors under the 30s Docker healthcheck — the same shape as
+    // the listTools() Ajv leak that OOM-restarted prod (#1663).
+    let settled = false;
+    const socket = netConnect({ path: pulseSocketPath });
+
+    const settle = (result: CheckResult, err?: unknown): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      socket.destroy();
+      if (result === 'fail') {
+        logger.warn({ err, pulseSocketPath }, 'checkSignalVoice: PulseAudio socket probe failed');
+      }
+      resolve(result);
+    };
+
+    const timer = setTimeout(() => settle('fail', new Error('timeout')), timeoutMs);
+    // Do not hold the process open for a health probe.
+    if (typeof timer.unref === 'function') timer.unref();
+
+    socket.once('connect', () => settle('ok'));
+    socket.once('error', (err) => settle('fail', err));
+  });
 }
 
 /**

--- a/src/health/health-service.ts
+++ b/src/health/health-service.ts
@@ -23,7 +23,7 @@ import { LlmOutcomeTracker } from './llm-outcome-tracker.js';
 import {
   checkDb, checkBus, checkEmail, checkSignal, checkBrowser,
   checkMcpServers, checkNylasCalendar, checkSlack, checkSms, checkVoice,
-  checkScheduler,
+  checkSignalVoice, checkScheduler,
   type EmailAdapterHealth, type SignalRpcClientHealth, type BrowserServiceHealth,
   type SlackClientHealth, type SmsChannelHealth, type VoiceLiveKitHealth,
 } from './health-checks.js';
@@ -47,6 +47,15 @@ export interface HealthServiceDeps {
    */
   nylasCalendarClient?: Pick<NylasCalendarClient, 'listCalendars'>;
   signalRpcClient?: SignalRpcClientHealth;
+  /**
+   * Path to the PulseAudio socket shared from the signal-cli container (#1760).
+   *
+   * Set ONLY when the Signal call bridge was actually constructed, so health mirrors
+   * what is running: absent → `skipped` (feature off, nothing to be unhealthy about),
+   * present → probed on every request. Passing the raw config value instead would
+   * report `fail` on instances that merely have the env var set.
+   */
+  signalPulseSocketPath?: string;
   browserService?: BrowserServiceHealth;
   /**
    * Slack Socket Mode client when the Slack adapter was constructed (#1567).
@@ -205,18 +214,19 @@ export class HealthService {
     const {
       db, bus, emailAdapter, signalRpcClient, browserService,
       mcpSessions, scheduler, config, nylasCalendarClient,
-      slackClient, smsHealth, voiceLiveKit,
+      slackClient, smsHealth, voiceLiveKit, signalPulseSocketPath,
     } = this.deps;
     const { liveness } = config;
     const mcpServerStatuses = this.deps.mcpServerStatuses ?? new Map();
 
     // Run all async probes concurrently to keep p99 latency low.
-    const [db_check, signal_check, mcp_checks, nylas_cal, voice_check] = await Promise.all([
+    const [db_check, signal_check, mcp_checks, nylas_cal, voice_check, signal_voice_check] = await Promise.all([
       checkDb(db, this.deps.logger),
       checkSignal(signalRpcClient, this.deps.logger),
       checkMcpServers(mcpServerStatuses, mcpSessions, this.deps.logger),
       checkNylasCalendar(nylasCalendarClient, this.deps.logger),
       checkVoice(voiceLiveKit, this.deps.logger),
+      checkSignalVoice(signalPulseSocketPath, this.deps.logger),
     ]);
 
     // Synchronous probes — no need to await.
@@ -238,6 +248,7 @@ export class HealthService {
       slack: slack_check,
       sms: sms_check,
       voice: voice_check,
+      signal_voice: signal_voice_check,
       scheduler: scheduler_check,
     };
 
@@ -387,6 +398,7 @@ export class HealthService {
       checks.slack,
       checks.sms,
       checks.voice,
+      checks.signal_voice,
       checks.scheduler,
     ];
     if (nonCritical.some(c => c === 'fail')) return 'degraded';

--- a/src/health/types.ts
+++ b/src/health/types.ts
@@ -23,6 +23,18 @@ export interface HealthResponse {
     sms: CheckResult;
     /** Voice/LiveKit management reachability; skipped when voice adapter absent (#1567). */
     voice: CheckResult;
+    /**
+     * Signal voice-CALL audio path: the shared PulseAudio socket (#1760). Skipped
+     * when the Signal call bridge was not constructed.
+     *
+     * Deliberately a sibling of `voice` rather than nesting it as
+     * `voice: { livekit, signal }`. The nested shape reads better, but `checks` is a
+     * public API surface consumed by the console and by external monitoring, and
+     * changing `voice` from CheckResult to an object breaks every existing consumer.
+     * Additive keys cost nothing: the console derives its chips by iterating
+     * `Object.entries(checks)`, so this renders with no console change.
+     */
+    signal_voice: CheckResult;
     scheduler: CheckResult;
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2004,7 +2004,11 @@ async function main(): Promise<void> {
           // most often missing LiveKit creds, since VoiceRuntime is built inside
           // the LiveKit-gated block (see the voiceRuntimeRef note above).
           hasVoiceRuntime: !!voiceRuntimeRef,
-          hasPulseSocket: !!config.signalPulseSocketPath,
+          // Named for what it actually is: the CONFIG VALUE being present, not the
+          // socket being alive. Conflating those is what let curia-deploy#221 run for
+          // hours with a dead audio stack and a green dashboard. Liveness now has its
+          // own probe — the `signal_voice` check in /api/health (#1760).
+          hasPulseSocketPath: !!config.signalPulseSocketPath,
           hasSignalChannel: channelShouldStart.has('signal'),
         },
         'SIGNAL_VOICE_CALLS_ENABLED is set but prerequisites are missing (needs the Signal channel + the full voice channel incl. LiveKit/Deepgram/Cartesia + the Pulse socket path); Signal voice calls disabled',
@@ -2225,6 +2229,13 @@ async function main(): Promise<void> {
           }),
         }
       : undefined,
+    // Gated on the BRIDGE existing, not on the config value (#1760). The bridge is
+    // what carries call audio over this socket; if it was never constructed there is
+    // nothing to be unhealthy about, so health reports `skipped`. Keying off
+    // `config.signalPulseSocketPath` instead would report `fail` on any instance that
+    // merely has the env var set — the same conflation of "configured" with "alive"
+    // that let curia-deploy#221 sit green for hours.
+    signalPulseSocketPath: signalCallBridge ? config.signalPulseSocketPath : undefined,
     mcpSessions,
     mcpServerStatuses,
     modelRoutingConfig,

--- a/tests/unit/health/check-signal-voice.test.ts
+++ b/tests/unit/health/check-signal-voice.test.ts
@@ -1,0 +1,137 @@
+// Tests for checkSignalVoice — the /api/health probe for the Signal voice audio
+// path (curia#1760).
+//
+// Why this check exists: during curia-deploy#221 the shared PulseAudio socket was
+// dead for hours, so Signal voice calls could not work at all, and the console
+// dashboard read "All systems nominal" with a green Voice chip. Nothing was lying:
+// `signal` probes the JSON-RPC socket (messaging) and `voice` probes LiveKit
+// (console/WebRTC voice). No check covered the Signal audio path at all.
+//
+// These tests use REAL Unix sockets rather than mocks, because the property under
+// test is precisely the one a mock would paper over: a stale socket inode with no
+// listener behind it must report `fail`. The dead container in #221 held exactly
+// that — a socket file at /tmp/pulse-runtime/pulse/native written by a daemon that
+// had been gone for a week. `test -S` passes against a corpse; connect() does not.
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { createServer, type Server } from 'node:net';
+import { spawn, type ChildProcess } from 'node:child_process';
+import { mkdtempSync, rmSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { checkSignalVoice, SIGNAL_VOICE_PROBE_TIMEOUT_MS } from '../../../src/health/health-checks.js';
+import type { Logger } from '../../../src/logger.js';
+
+const stubLogger = { warn: () => {} } as unknown as Logger;
+
+// Unix socket paths are capped near 104 bytes on macOS, so keep the temp dir short.
+const dirs: string[] = [];
+const servers: Server[] = [];
+const children: ChildProcess[] = [];
+
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'pa-'));
+  dirs.push(dir);
+  return dir;
+}
+
+/** A listening Unix socket — stands in for a live PulseAudio daemon. */
+async function liveSocket(): Promise<string> {
+  const path = join(tempDir(), 'native');
+  const server = createServer();
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(path, resolve));
+  return path;
+}
+
+/**
+ * A real socket inode with nothing listening — the #221 shape.
+ *
+ * Built by listening in a CHILD process and SIGKILLing it. That matters: an
+ * in-process `server.close()` unlinks the path, and writing a regular file in its
+ * place would fail the probe with ENOTSOCK, which is a different error than the one
+ * production hit. SIGKILL runs no cleanup, so the socket inode survives exactly as
+ * it did in the dead container — `srwxrwxrwx native`, owner long gone. The assertion
+ * below pins that: if this ever stops being a socket, the test is no longer covering
+ * the case it claims to.
+ */
+async function staleSocket(): Promise<string> {
+  const path = join(tempDir(), 'native');
+  const child = spawn(process.execPath, [
+    '-e',
+    "require('net').createServer().listen(process.argv[1], () => console.log('ready'))",
+    path,
+  ]);
+  children.push(child);
+  await new Promise<void>((resolve, reject) => {
+    child.stdout.once('data', () => resolve());
+    child.once('error', reject);
+    child.once('exit', (code) => reject(new Error(`helper exited early (${code})`)));
+  });
+  child.kill('SIGKILL');
+  await new Promise<void>((resolve) => child.once('exit', () => resolve()));
+  // The inode must have outlived the process, or this test proves nothing.
+  expect(statSync(path).isSocket()).toBe(true);
+  return path;
+}
+
+afterEach(() => {
+  for (const c of children.splice(0)) if (!c.killed) c.kill('SIGKILL');
+  for (const s of servers.splice(0)) s.close();
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+
+describe('checkSignalVoice', () => {
+  it('returns skipped when the Signal voice path is not configured', async () => {
+    // No socket path => the call bridge was never constructed. Not a failure:
+    // an instance without Signal voice must not show a permanently red chip.
+    expect(await checkSignalVoice(undefined, stubLogger)).toBe('skipped');
+  });
+
+  it('returns ok when a daemon is listening on the socket', async () => {
+    expect(await checkSignalVoice(await liveSocket(), stubLogger)).toBe('ok');
+  });
+
+  it('returns fail when the socket path does not exist', async () => {
+    // The #221 production shape: /var/run/pulse-shared/ was empty because pulse
+    // never started.
+    const missing = join(tempDir(), 'native');
+    expect(await checkSignalVoice(missing, stubLogger)).toBe('fail');
+  });
+
+  it('returns fail for a stale socket inode with no listener', async () => {
+    // THE central case. A `test -S`-style existence check passes here and reports
+    // a dead audio stack as healthy. Connecting is what tells them apart.
+    expect(await checkSignalVoice(await staleSocket(), stubLogger)).toBe('fail');
+  });
+
+  it('does not leave the probe connection open', async () => {
+    // A liveness endpoint is hit every 30s by the Docker healthcheck. A probe that
+    // leaks a socket per call exhausts descriptors — the same shape as the
+    // listTools() Ajv leak that OOM-restarted prod (#1663).
+    const path = await liveSocket();
+    const server = servers[servers.length - 1]!;
+    let open = 0;
+    server.on('connection', (sock) => { open++; sock.on('close', () => { open--; }); });
+
+    for (let i = 0; i < 5; i++) expect(await checkSignalVoice(path, stubLogger)).toBe('ok');
+    await new Promise((r) => setTimeout(r, 50));
+    expect(open).toBe(0);
+  });
+
+  it('settles quickly instead of hanging', async () => {
+    // A liveness endpoint that can block forever is worse than one reporting fail.
+    //
+    // The timer inside the probe is deliberately NOT asserted directly: a Unix-socket
+    // connect resolves or errors in the same tick, so a timeout cannot be triggered
+    // deterministically without injecting a fake connector — a seam that would exist
+    // only for this test. The timer stays as defence for the case the kernel can
+    // still produce (a daemon listening with a saturated backlog). What is worth
+    // pinning, and what this asserts, is the contract callers depend on: every
+    // outcome settles well inside the probe budget.
+    const missing = join(tempDir(), 'native');
+    const started = Date.now();
+    expect(await checkSignalVoice(missing, stubLogger)).toBe('fail');
+    expect(Date.now() - started).toBeLessThan(SIGNAL_VOICE_PROBE_TIMEOUT_MS);
+  });
+});

--- a/tests/unit/health/health-service.test.ts
+++ b/tests/unit/health/health-service.test.ts
@@ -90,6 +90,29 @@ describe('HealthService.getStatus()', () => {
     expect(result.checks.voice).toBe('fail');
   });
 
+  // #1760. Two separate wiring mistakes are easy to make here and neither is caught
+  // by the probe's own unit tests: forgetting to surface the check in `checks`, and
+  // forgetting to add it to aggregateStatus's `nonCritical` list — that list is
+  // enumerated by hand, so a new key renders a console chip while the overall status
+  // dot stays green. That is the exact failure mode #1760 was filed about.
+  it('returns degraded when the Signal voice audio socket is dead (#1760)', async () => {
+    const svc = new HealthService(makeDeps({
+      // Path that cannot connect — stands in for a dead PulseAudio daemon.
+      signalPulseSocketPath: '/nonexistent/pulse-shared/native',
+    }) as never);
+    const result = await svc.getStatus();
+    expect(result.checks.signal_voice).toBe('fail');
+    expect(result.status).toBe('degraded');
+  });
+
+  it('skips the Signal voice check when the call bridge was not constructed (#1760)', async () => {
+    // Instances without Signal voice must not show a permanently failing chip.
+    const svc = new HealthService(makeDeps({}) as never);
+    const result = await svc.getStatus();
+    expect(result.checks.signal_voice).toBe('skipped');
+    expect(result.status).toBe('ok');
+  });
+
   it('reports ok for healthy Slack/SMS/Voice probes (#1567)', async () => {
     const svc = new HealthService(makeDeps({
       slackClient: {


### PR DESCRIPTION
Closes #1760.

During curia-deploy#221 the shared PulseAudio socket was dead for hours — Signal voice calls could not carry audio at all — and the dashboard read **"All systems nominal"** with a green **Voice** chip.

Nothing was lying. `signal` probes the JSON-RPC socket (messaging); `voice` probes LiveKit `listRooms()` (console/WebRTC voice). A grep for `pulse` across `src/health/` returned nothing. The console faithfully renders `/api/health`, so this was a missing probe, not a rendering bug.

## The probe connects, it does not stat

`test -S` cannot tell a live daemon from a corpse. The #221 container held a socket inode written by a daemon dead for a week — `srwxrwxrwx native`, owner long gone.

The regression test builds exactly that shape rather than mocking it: listen in a **child process**, `SIGKILL` it so no cleanup runs, then assert the inode survived before probing.

```ts
// The inode must have outlived the process, or this test proves nothing.
expect(statSync(path).isSocket()).toBe(true);
```

An existence check passes that fixture. This probe reports `fail`.

An in-process `server.close()` would unlink the path, and dropping a regular file there fails with `ENOTSOCK` — a different error than production hit. Hence the child process.

## Wiring details that are easy to get wrong

Each has a test, because none is caught by the probe's own unit tests:

- **`aggregateStatus` enumerates checks by hand.** A new key renders a console chip while the overall status dot stays green — precisely the failure mode #1760 is about. I verified the guard bites by removing the wiring and watching the test fail, then restoring it.
- **The dep is gated on the call *bridge* existing**, not on `config.signalPulseSocketPath`. Keying off config would report `fail` on any instance that merely has the env var set — the same conflation of "configured" with "alive" that let #221 sit green.
- **`skipped` when the bridge is absent**, matching `checkVoice`, so instances without Signal voice show no permanently red chip.

## Shape: additive, not nested

`voice: { livekit, signal }` reads better, but `checks` is a public API surface consumed by the console and external monitoring, and changing `voice` from `CheckResult` to an object breaks every consumer. So `signal_voice` is a sibling key.

The console needs **no change** either way — its `checks` type is `Record<string, CheckResult | Record<string, CheckResult>>` and it derives chips by iterating `Object.entries`. A console test pins that contract, since narrowing it later would silently hide backend failures from the operator.

## Also

`hasPulseSocket` in the boot-gate log is renamed `hasPulseSocketPath`. It only ever meant "the env var is set"; reading it as liveness is part of why #221 was invisible.

## Known tradeoff

Connecting without a handshake may make PulseAudio log a short-lived client per probe, and the Docker healthcheck hits `/api/health` every 30s. Accepted deliberately and documented in the code: a handshake-free connect cannot desync from a protocol change, and the alternative is the existence check that started this. If the log noise ever obscures debugging, raise the probe interval rather than weaken it back.

## Verification

- `pnpm typecheck` — clean across root, skills, tests, scripts, and all three workspace packages
- `pnpm lint` — clean (one pre-existing warning in `src/pii/scrubber.ts`, untouched here)
- `pnpm test` — **6375 passed, 0 failed** (388 skipped)
- New: 6 probe tests, 2 service-wiring tests, 1 console contract test

## Related audit

While here I checked the other probes for the same stat-vs-connect shape, per the follow-up request. Findings filed separately as #1762 — `checkBrowser` is the notable one, and it comes with a contradiction in the existing comments worth resolving.
