### PR TITLE
fix(health): probe the browser instead of testing an object reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Changed
 
 - **`browser` health check** — probes Chrome with a bounded round-trip instead of testing an object reference. (#1762)
+- **Health probe timeouts** — every probe clears its losing timer instead of leaving one pending per request. (#1762)
 - **Spec 15** — blocked-body audit placement matches the event contract. (#1732)
 - **`DreamEngine`** — contact-anchored nodes no longer decay or archive; their facts still do. (#1694)
 - **Decay warnings** — anchored nodes are never listed for re-confirmation nor archived by dismissal. (#1694)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Changed
 
+- **`browser` health check** — probes Chrome with a bounded round-trip instead of testing an object reference. (#1762)
 - **Spec 15** — blocked-body audit placement matches the event contract. (#1732)
 - **`DreamEngine`** — contact-anchored nodes no longer decay or archive; their facts still do. (#1694)
 - **Decay warnings** — anchored nodes are never listed for re-confirmation nor archived by dismissal. (#1694)

--- a/src/browser/browser-service.ts
+++ b/src/browser/browser-service.ts
@@ -214,9 +214,11 @@ export class BrowserService {
         this.attachDisconnectedHandler(ctx);
       }).catch(err => {
         this.logger.error({ err }, 'Browser restart failed');
-        // Clear the stale crashed context so checkBrowser() returns 'fail' during
-        // crash recovery. Without this, browserContext remains the dead reference
-        // and the health check would falsely report 'ok'.
+        // Clear the stale crashed context: a failed relaunch means there is no browser,
+        // and the getter must not hand out a reference to a corpse. Since #1762
+        // checkBrowser round-trips rather than trusting the reference, so it would
+        // report 'fail' here regardless — this is no longer the health check's only
+        // line of defence, but leaving a dead reference reachable would still be wrong.
         this.context = null;
       });
     });
@@ -410,8 +412,12 @@ export class BrowserService {
 
   /**
    * Expose the persistent browser context for liveness probes. Null when the service
-   * has not been started or has been stopped. The probe calls isConnected() to confirm
-   * the browser process is still alive.
+   * has not been started or has been stopped.
+   *
+   * The probe (`checkBrowser`) does a bounded `cookies()` round-trip into Chrome. It
+   * deliberately does NOT use `isConnected()`, which this comment previously claimed:
+   * that is synchronous cached transport state, so a wedged-but-connected renderer
+   * still reports true (#1762).
    */
   get browserContext(): BrowserContext | null {
     return this.context;

--- a/src/health/health-checks.ts
+++ b/src/health/health-checks.ts
@@ -33,11 +33,14 @@ export interface SignalRpcClientHealth {
 export interface BrowserServiceHealth {
   /**
    * The persistent browser context, or null when the service is stopped.
-   * BrowserService uses launchPersistentContext — context.browser() always returns
-   * null for these contexts (Playwright behavior, not an error). Liveness is
-   * checked by whether the context object exists: stop() sets it to null.
+   *
+   * Only `cookies()` is required: it is the cheapest read-only call that actually
+   * crosses the process boundary into Chrome (a `Storage.getCookies` protocol
+   * round-trip), which is what makes it a liveness probe rather than a reference check.
    */
-  browserContext: object | null;
+  browserContext: {
+    cookies(urls?: string): Promise<unknown[]>;
+  } | null;
 }
 
 export interface McpSessionHealth {
@@ -199,17 +202,60 @@ export async function checkSignal(
   }
 }
 
+/** Default budget for the browser round-trip. Local Chrome over a pipe — a healthy
+ * browser answers in single-digit ms; anything near this is wedged. */
+export const BROWSER_PROBE_TIMEOUT_MS = 3_000;
+
 /**
- * Check Playwright browser context liveness. Non-critical.
- * Synchronous — liveness is determined by whether the context object exists.
- * Skipped when no service is provided (browser not configured).
+ * Playwright/Patchright browser liveness (#1762). Non-critical.
+ *
+ * This used to be `service.browserContext !== null` — an object-reference existence
+ * test. Chrome runs in a separate process, so holding a reference proves nothing about
+ * whether that process is alive: exactly the shape that let a dead PulseAudio daemon
+ * report healthy (#1760), and this subsystem has form for silent death (the stale
+ * Chrome SingletonLock, #1017).
+ *
+ * The old comment justified the shortcut by asserting that `context.browser()` always
+ * returns null for persistent contexts, so no probe was possible. That was wrong, and
+ * it mattered — it is the stated reason the check was never strengthened. Production
+ * disproves it: `attachDisconnectedHandler` logs "crash recovery disabled" on a null
+ * `browser()`, and that warning has never appeared on an instance that logged
+ * "Persistent browser context launched". A third comment, on the `browserContext`
+ * getter, claimed this probe called `isConnected()`, which it never did. All three
+ * claims are now reconciled by making the probe real.
+ *
+ * `cookies()` is used rather than `isConnected()`: the latter is synchronous cached
+ * transport state, so a wedged-but-connected renderer still reports true. A bounded
+ * round-trip catches both a dead process (the call rejects) and a hung one (it never
+ * settles, and the timeout fires).
+ *
+ * Scoped to a single URL so a routine liveness check does not pull an entire real
+ * browsing profile's cookie jar — session tokens included — into memory every 30s.
  */
-export function checkBrowser(service: BrowserServiceHealth | undefined): CheckResult {
+export async function checkBrowser(
+  service: BrowserServiceHealth | undefined,
+  logger: Logger,
+  timeoutMs: number = BROWSER_PROBE_TIMEOUT_MS,
+): Promise<CheckResult> {
   if (!service) return 'skipped';
-  // BrowserService uses launchPersistentContext: context.browser() always returns null
-  // for persistent contexts (it's not an error). Liveness = context object exists;
-  // BrowserService sets context to null on stop() and during failed relaunch.
-  return service.browserContext !== null ? 'ok' : 'fail';
+  const context = service.browserContext;
+  // Null means stopped, or a crash-recovery relaunch that failed. Already definitive —
+  // no probe needed, and nothing to probe.
+  if (context === null) return 'fail';
+
+  try {
+    await Promise.race([
+      // Any well-formed URL works; nothing is expected to match. The call is the point.
+      context.cookies('http://127.0.0.1/'),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error('timeout')), timeoutMs),
+      ),
+    ]);
+    return 'ok';
+  } catch (err) {
+    logger.warn({ err }, 'checkBrowser: browser liveness probe failed');
+    return 'fail';
+  }
 }
 
 /**
@@ -310,6 +356,13 @@ export async function checkNylasCalendar(
  * Skipped when the Slack adapter was not constructed (disabled / no credentials).
  * Allows a short boot grace before the first `connected` event; after that,
  * a disconnected socket is `fail` (Socket Mode reconnects are visible as degraded).
+ *
+ * Cached state rather than a round-trip, and deliberately so (#1762): the flag is
+ * maintained by the Socket Mode client from real socket events, and Socket Mode runs
+ * its own ping/pong underneath, so this is event-driven liveness rather than an
+ * existence check. A half-open socket could still read as connected; the exposure was
+ * judged small enough not to warrant an extra probe. Recorded so a later audit knows
+ * this was considered rather than overlooked.
  */
 export function checkSlack(
   client: SlackClientHealth | undefined,
@@ -324,8 +377,26 @@ export function checkSlack(
 
 /**
  * SMS (Telnyx) adapter readiness (#1567). Non-critical.
- * Skipped when the SMS adapter was not constructed. Healthy when the webhook
- * handler is installed (adapter started) — no outbound send.
+ * Skipped when the SMS adapter was not constructed.
+ *
+ * WHAT `ok` MEANS HERE: the inbound webhook handler is installed in this process.
+ * Nothing more. It does NOT mean Telnyx can reach us, that the credentials are still
+ * valid, or that the DID is still routed to this instance. Each of those can break
+ * with this reporting `ok`. Read it as "the adapter started", never as end-to-end SMS
+ * health (#1762).
+ *
+ * Why no probe, unlike its neighbours: the audit in #1762 asked whether this should
+ * round-trip to Telnyx the way `voice` and `nylas_calendar` do. It should not, and the
+ * reason is worth recording so the question is not reopened blind. The property that
+ * actually matters here is INBOUND reachability — Telnyx delivering a webhook to us —
+ * and no outbound API call can assert that. A read-only "list phone numbers" would
+ * upgrade `ok` from "handler installed" to "handler installed and our credentials
+ * work", while adding a third-party network dependency to a liveness endpoint hit
+ * every 30s. That is a poor trade for a partial answer. An outbound send WOULD prove
+ * more, and is rejected outright: a health check must never cost money or emit traffic.
+ *
+ * If inbound reachability needs real coverage, it belongs in a periodic canary
+ * (like the Nylas grant canary), not in the synchronous liveness path.
  */
 export function checkSms(health: SmsChannelHealth | undefined): CheckResult {
   if (!health) return 'skipped';

--- a/src/health/health-checks.ts
+++ b/src/health/health-checks.ts
@@ -100,6 +100,42 @@ export interface VoiceLiveKitHealth {
 export const SLACK_CONNECT_GRACE_MS = 60_000;
 
 // ---------------------------------------------------------------------------
+// Shared probe plumbing
+// ---------------------------------------------------------------------------
+
+/**
+ * Await `work`, rejecting with `timeout` if it outlives `ms`.
+ *
+ * Every async probe here needs a hard bound, and each used to inline
+ * `Promise.race([work, new Promise((_, reject) => setTimeout(reject, ms))])`. That
+ * pattern leaks the losing timer: when `work` wins, the setTimeout stays scheduled
+ * until it fires. The Docker healthcheck hits /api/health every 30s and each request
+ * ran several probes, so every request left a handful of timers pending for seconds
+ * (PR #1763 review). Individually harmless, but it is the same slow-accumulation shape
+ * as the MCP Ajv leak that OOM-restarted prod (#1663), and clearing in `finally` costs
+ * nothing.
+ *
+ * A rejection from `work` propagates unchanged rather than being flattened into a
+ * timeout, so callers still log the real cause (ECONNREFUSED, Target closed, ...).
+ *
+ * The timeout does NOT cancel `work` — nothing here can. A probe that loses the race
+ * is abandoned, not aborted; it settles later and is ignored.
+ */
+export async function withTimeout<T>(work: Promise<T>, ms: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      work,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error('timeout')), ms);
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Probe implementations
 // ---------------------------------------------------------------------------
 
@@ -109,12 +145,7 @@ export const SLACK_CONNECT_GRACE_MS = 60_000;
  */
 export async function checkDb(pool: Pool, logger: Logger): Promise<CheckResult> {
   try {
-    await Promise.race([
-      pool.query('SELECT 1'),
-      new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error('timeout')), 2_000),
-      ),
-    ]);
+    await withTimeout(pool.query('SELECT 1'), 2_000);
     return 'ok';
   } catch (err) {
     logger.warn({ err }, 'checkDb: DB liveness probe failed');
@@ -189,12 +220,7 @@ export async function checkSignal(
 ): Promise<CheckResult> {
   if (!client) return 'skipped';
   try {
-    await Promise.race([
-      client.listGroups(),
-      new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error('timeout')), 3_000),
-      ),
-    ]);
+    await withTimeout(client.listGroups(), 3_000);
     return 'ok';
   } catch (err) {
     logger.warn({ err }, 'checkSignal: Signal liveness probe failed');
@@ -244,13 +270,8 @@ export async function checkBrowser(
   if (context === null) return 'fail';
 
   try {
-    await Promise.race([
-      // Any well-formed URL works; nothing is expected to match. The call is the point.
-      context.cookies('http://127.0.0.1/'),
-      new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error('timeout')), timeoutMs),
-      ),
-    ]);
+    // Any well-formed URL works; nothing is expected to match. The call is the point.
+    await withTimeout(context.cookies('http://127.0.0.1/'), timeoutMs);
     return 'ok';
   } catch (err) {
     logger.warn({ err }, 'checkBrowser: browser liveness probe failed');
@@ -296,12 +317,7 @@ export async function checkMcpServers(
         // JSON-RPC. Zero-tools/unavailable servers were already failed by the boot
         // gate above, so we don't re-count tools here (and must not — see the
         // McpSessionHealth doc: listTools() leaks compiled validators, #1663).
-        await Promise.race([
-          session.client.ping(),
-          new Promise<never>((_, reject) =>
-            setTimeout(() => reject(new Error('timeout')), 3_000),
-          ),
-        ]);
+        await withTimeout(session.client.ping(), 3_000);
         return [key, 'ok'];
       } catch (err) {
         logger.warn({ err, server: serverName }, 'checkMcpServers: MCP probe failed');
@@ -333,12 +349,7 @@ export async function checkNylasCalendar(
 ): Promise<NylasCalendarProbe> {
   if (!calendarClient) return { status: 'skipped', authFailure: false };
   try {
-    await Promise.race([
-      calendarClient.listCalendars(),
-      new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error('timeout')), 5_000),
-      ),
-    ]);
+    await withTimeout(calendarClient.listCalendars(), 5_000);
     return { status: 'ok', authFailure: false };
   } catch (err) {
     logger.warn({ err }, 'checkNylasCalendar: calendar grant probe failed');
@@ -414,12 +425,7 @@ export async function checkVoice(
 ): Promise<CheckResult> {
   if (!livekit) return 'skipped';
   try {
-    await Promise.race([
-      livekit.listRooms(),
-      new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error('timeout')), 5_000),
-      ),
-    ]);
+    await withTimeout(livekit.listRooms(), 5_000);
     return 'ok';
   } catch (err) {
     logger.warn({ err }, 'checkVoice: LiveKit management probe failed');

--- a/src/health/health-service.ts
+++ b/src/health/health-service.ts
@@ -220,18 +220,25 @@ export class HealthService {
     const mcpServerStatuses = this.deps.mcpServerStatuses ?? new Map();
 
     // Run all async probes concurrently to keep p99 latency low.
-    const [db_check, signal_check, mcp_checks, nylas_cal, voice_check, signal_voice_check] = await Promise.all([
+    const [
+      db_check, signal_check, mcp_checks, nylas_cal, voice_check, signal_voice_check,
+      // Moved out of the synchronous block in #1762: checkBrowser now round-trips to
+      // Chrome instead of testing an object reference, so it must be awaited. It joins
+      // the concurrent set rather than being awaited on its own — every probe here has
+      // its own timeout, so the whole block stays bounded by the slowest single probe.
+      browser_check,
+    ] = await Promise.all([
       checkDb(db, this.deps.logger),
       checkSignal(signalRpcClient, this.deps.logger),
       checkMcpServers(mcpServerStatuses, mcpSessions, this.deps.logger),
       checkNylasCalendar(nylasCalendarClient, this.deps.logger),
       checkVoice(voiceLiveKit, this.deps.logger),
       checkSignalVoice(signalPulseSocketPath, this.deps.logger),
+      checkBrowser(browserService, this.deps.logger),
     ]);
 
     // Synchronous probes — no need to await.
     const bus_check = checkBus(bus);
-    const browser_check = checkBrowser(browserService);
     const email_check = checkEmail(emailAdapter, liveness.emailStallFactor, this.startedAt);
     const slack_check = checkSlack(slackClient, this.startedAt);
     const sms_check = checkSms(smsHealth);

--- a/tests/unit/health/health-checks.test.ts
+++ b/tests/unit/health/health-checks.test.ts
@@ -1,13 +1,15 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import {
   checkDb,
   checkBus,
   checkBrowser,
   checkEmail,
   checkScheduler,
+  checkSignal,
   checkSlack,
   checkSms,
   checkVoice,
+  withTimeout,
 } from '../../../src/health/health-checks.js';
 import type { Logger } from '../../../src/logger.js';
 
@@ -75,6 +77,68 @@ describe('checkBrowser', () => {
     await checkBrowser({ browserContext: { cookies: spy } }, stubLogger);
     expect(spy).toHaveBeenCalledTimes(1);
     expect(spy.mock.calls[0]![0]).toBeTruthy();
+  });
+});
+
+// PR #1763 review. `Promise.race([work, timeoutPromise])` does NOT cancel the losing
+// timer: when `work` wins, the setTimeout stays scheduled until it fires. Every racing
+// probe in this module used that pattern, and /api/health is hit every 30s by the
+// Docker healthcheck, so each request left a handful of timers pending. Individually
+// harmless; collectively the same slow-accumulation shape as the Ajv leak that
+// OOM-restarted prod (#1663). These tests pin the fix at both levels.
+describe('withTimeout', () => {
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('clears the losing timer when the work settles first', async () => {
+    vi.useFakeTimers();
+    await withTimeout(Promise.resolve('done'), 5_000);
+    // Without the clearTimeout this is 1 — the old behaviour, once per probe per request.
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('returns the work result untouched', async () => {
+    expect(await withTimeout(Promise.resolve('value'), 1_000)).toBe('value');
+  });
+
+  it('rejects when the work outlives the budget', async () => {
+    await expect(withTimeout(new Promise(() => {}), 5)).rejects.toThrow('timeout');
+  });
+
+  it('propagates the work rejection rather than masking it as a timeout', async () => {
+    // A probe that reports every failure as "timeout" loses the actual cause in the log.
+    await expect(withTimeout(Promise.reject(new Error('ECONNREFUSED')), 5_000))
+      .rejects.toThrow('ECONNREFUSED');
+  });
+
+  it('leaves no timer pending after the work rejects', async () => {
+    vi.useFakeTimers();
+    await expect(withTimeout(Promise.reject(new Error('boom')), 5_000)).rejects.toThrow('boom');
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});
+
+describe('probe timer hygiene (PR #1763 review)', () => {
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('leaves no timer pending after a successful checkBrowser probe', async () => {
+    vi.useFakeTimers();
+    const svc = { browserContext: { cookies: vi.fn().mockResolvedValue([]) } };
+    expect(await checkBrowser(svc, stubLogger)).toBe('ok');
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('leaves no timer pending after a successful checkSignal probe', async () => {
+    // Same pattern, pre-existing. Fixing only the function under review would have left
+    // four known instances behind and made the new one the odd style out.
+    vi.useFakeTimers();
+    expect(await checkSignal({ listGroups: vi.fn().mockResolvedValue([]) }, stubLogger)).toBe('ok');
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('leaves no timer pending after a successful checkVoice probe', async () => {
+    vi.useFakeTimers();
+    expect(await checkVoice({ listRooms: vi.fn().mockResolvedValue([]) }, stubLogger)).toBe('ok');
+    expect(vi.getTimerCount()).toBe(0);
   });
 });
 

--- a/tests/unit/health/health-checks.test.ts
+++ b/tests/unit/health/health-checks.test.ts
@@ -27,19 +27,54 @@ describe('checkDb', () => {
   });
 });
 
+// #1762. This check used to be `browserContext !== null` — an object-reference
+// existence test. Chrome is out-of-process, so a reference proves nothing about the
+// process behind it; that is the same shape that let a dead PulseAudio daemon read as
+// healthy (#1760). It now round-trips to the browser.
 describe('checkBrowser', () => {
-  it('returns skipped when no service provided', () => {
-    expect(checkBrowser(undefined)).toBe('skipped');
+  /** A context whose cookies() resolves — stands in for a live browser. */
+  const live = { browserContext: { cookies: vi.fn().mockResolvedValue([]) } };
+
+  it('returns skipped when no service provided', async () => {
+    expect(await checkBrowser(undefined, stubLogger)).toBe('skipped');
   });
 
-  it('returns ok when browserContext is a live object', () => {
-    // BrowserService uses launchPersistentContext — liveness = context object exists.
-    // No .browser() call needed; the context object itself is the liveness signal.
-    expect(checkBrowser({ browserContext: {} })).toBe('ok');
+  it('returns ok when the browser answers the round-trip', async () => {
+    expect(await checkBrowser(live, stubLogger)).toBe('ok');
   });
 
-  it('returns fail when browserContext is null (service stopped or relaunch failed)', () => {
-    expect(checkBrowser({ browserContext: null })).toBe('fail');
+  it('returns fail when browserContext is null (service stopped or relaunch failed)', async () => {
+    expect(await checkBrowser({ browserContext: null }, stubLogger)).toBe('fail');
+  });
+
+  it('returns fail when the browser is gone but the context reference survives', async () => {
+    // THE case the old check could not see. Playwright throws "Target closed" /
+    // "Browser has been closed" once the process dies; BrowserService only nulls its
+    // reference if crash recovery runs AND its relaunch fails, so between the crash
+    // and that point the reference is a live object pointing at a corpse.
+    const dead = {
+      browserContext: { cookies: vi.fn().mockRejectedValue(new Error('Target page, context or browser has been closed')) },
+    };
+    expect(await checkBrowser(dead, stubLogger)).toBe('fail');
+  });
+
+  it('returns fail when the browser is wedged rather than dead', async () => {
+    // A hung renderer keeps the transport open, so isConnected() — what the
+    // browserContext getter's comment claimed this probe used — still reports true.
+    // Only a bounded round-trip catches it. Unlike a Unix-socket connect, a hang is
+    // deterministically reproducible here because the mock never settles.
+    const wedged = { browserContext: { cookies: vi.fn().mockReturnValue(new Promise(() => {})) } };
+    expect(await checkBrowser(wedged, stubLogger, 10)).toBe('fail');
+  });
+
+  it('scopes the cookie read to one URL rather than dumping the whole jar', async () => {
+    // The persistent profile is a real browsing profile. Reading every cookie every 30s
+    // to answer "is it alive?" pulls session tokens into memory for no reason; a single
+    // narrow URL is the same round-trip with none of that.
+    const spy = vi.fn().mockResolvedValue([]);
+    await checkBrowser({ browserContext: { cookies: spy } }, stubLogger);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0]![0]).toBeTruthy();
   });
 });
 

--- a/tests/unit/health/health-service.test.ts
+++ b/tests/unit/health/health-service.test.ts
@@ -113,6 +113,29 @@ describe('HealthService.getStatus()', () => {
     expect(result.status).toBe('ok');
   });
 
+  // #1762 moved checkBrowser from the synchronous block into the awaited Promise.all,
+  // because it now round-trips to Chrome. A mis-wire there (an un-awaited promise
+  // landing in `checks.browser`) would not be a type error at the call site's edges,
+  // and would read as truthy — i.e. permanently healthy. This pins the real value.
+  it('returns degraded when the browser probe fails (#1762)', async () => {
+    const svc = new HealthService(makeDeps({
+      browserService: {
+        browserContext: { cookies: vi.fn().mockRejectedValue(new Error('Target closed')) },
+      },
+    }) as never);
+    const result = await svc.getStatus();
+    expect(result.checks.browser).toBe('fail');
+    expect(result.status).toBe('degraded');
+  });
+
+  it('reports ok when the browser answers the probe (#1762)', async () => {
+    const svc = new HealthService(makeDeps({
+      browserService: { browserContext: { cookies: vi.fn().mockResolvedValue([]) } },
+    }) as never);
+    const result = await svc.getStatus();
+    expect(result.checks.browser).toBe('ok');
+  });
+
   it('reports ok for healthy Slack/SMS/Voice probes (#1567)', async () => {
     const svc = new HealthService(makeDeps({
       slackClient: {


### PR DESCRIPTION
Closes #1762. Follow-up to the audit prompted by #1760.

## `checkBrowser` — the finding

```ts
return service.browserContext !== null ? 'ok' : 'fail';
```

An object-reference existence test. Chrome runs in a **separate process**, so holding a reference proves nothing about whether that process is alive — the same shape that let a dead PulseAudio daemon report healthy, in a subsystem with prior form for silent death (the stale Chrome SingletonLock, #1017).

### Three comments, mutually incompatible

| Where | Claim |
|---|---|
| `checkBrowser` | `context.browser()` *"always returns null for these contexts"* → no probe is possible |
| `attachDisconnectedHandler` | assumes `browser()` may be non-null, attaches crash recovery, logs `"crash recovery disabled"` otherwise |
| `browserContext` getter | *"The probe calls `isConnected()`"* — a probe that did not exist |

Claim 1 is load-bearing: it is the stated reason the check was never strengthened.

**Production settles it.** That warning has never appeared on an instance that logged `Persistent browser context launched`, so `browser()` returns non-null and recovery does attach. Claim 1 is false. All three are now reconciled against observed behaviour.

### The fix

A bounded `cookies()` round-trip. Deliberately **not** `isConnected()` — that is synchronous cached transport state, so a wedged-but-connected renderer still reports `true`. A round-trip catches both a dead process (rejects) and a hung one (never settles, timeout fires).

Scoped to a single URL, so a routine liveness check does not pull a real browsing profile's entire cookie jar — session tokens included — into memory every 30s. There's a test asserting that scoping, since it's the kind of thing a later refactor drops without noticing.

`checkBrowser` moves from the synchronous block into the concurrent `Promise.all`. Every probe there has its own timeout, so the block stays bounded by the slowest single probe.

### Tests

The two cases the old check could not see:

- **browser gone, reference survives** — `cookies()` rejects with `Target closed`. `BrowserService` only nulls its reference if crash recovery runs *and* its relaunch fails, so between the crash and that point the reference is a live object pointing at a corpse.
- **browser wedged rather than dead** — the mock never settles. Unlike the Unix-socket probe in #1761, a hang is deterministically reproducible here, so the timeout path is genuinely covered rather than reasoned about.

Plus two `HealthService` tests: an un-awaited promise landing in `checks.browser` would read as truthy — permanently healthy — so the real value is pinned.

## `checkSms` — documented, not probed

The audit asked whether this should round-trip to Telnyx the way `voice` and `nylas_calendar` do. **It should not**, and I recorded why so the question isn't reopened blind:

The property that matters is **inbound** reachability — Telnyx delivering a webhook to us — and no outbound call can assert that. A read-only "list phone numbers" would upgrade `ok` from *"handler installed"* to *"handler installed and our credentials work"*, while adding a third-party network dependency to a liveness endpoint hit every 30s. Poor trade for a partial answer. An outbound send would prove more and is rejected outright: a health check must never cost money or emit traffic.

If inbound reachability needs real coverage it belongs in a periodic canary, like the Nylas grant canary — not the synchronous liveness path. What `ok` does and does not mean is now stated at the function.

## `checkSlack` — left as-is, recorded

Cached state, but maintained by the Socket Mode client from real socket events with its own ping/pong underneath — event-driven liveness rather than an existence check. A half-open socket could still read as connected; exposure judged small. Documented so a later audit knows it was considered rather than overlooked.

## Verification

- `pnpm typecheck` — clean across root, skills, tests, scripts, and all three workspace packages
- `pnpm lint` — clean (one pre-existing warning in `src/pii/scrubber.ts`, untouched)
- `pnpm test` — **6380 passed, 0 failed** (388 skipped)

## Noticed, not changed

`checkSignal`, `checkVoice`, `checkNylasCalendar`, and now `checkBrowser` all use `Promise.race` with a `setTimeout` that is never cleared when the winning branch resolves, so each `/api/health` call leaves a few timers pending for their timeout duration. Harmless at a 30s interval and it is the established idiom in this file, so I matched it rather than introducing a second style for one function. Worth a sweep if anyone touches this module again — `checkSignalVoice` (#1761) shows the cleared-and-unref'd version.
