### PR TITLE
fix(deps): pin smol-toml to >=1.7.1 (GHSA-7w5x-hrqm-74c2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Docker image** — keep pnpm's metadata cache; removing it timed out the deploy's lockfile verification. (#1758)
 - **Docker image** — keep pnpm's store; removing it made the deploy build re-download every package. (#1756)
 - **Semgrep SARIF** — `# nosemgrep`-suppressed findings no longer upload as open code-scanning alerts. (#1754)
+- **Dependency pin** — `smol-toml` pinned to `>=1.7.1`, clearing a HIGH DoS advisory in a dev-only transitive dep. (GHSA-7w5x-hrqm-74c2)
 - **Dependency pins** — `qs`, `hono`, and `fflate` raised to patched releases, clearing six advisories. (#1752)
 - **Docker image** — drop pnpm's metadata cache and store from the runtime image; they aren't used at runtime. (#1750)
 - **Docker image** — remove unused global npm so bundled brace-expansion/tar CVEs clear. (#1568)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,7 @@ overrides:
   brace-expansion: '>=5.0.8'
   gaxios>rimraf: '>=6.1.2'
   fflate: '>=0.8.3'
+  smol-toml: '>=1.7.1'
 
 importers:
 
@@ -5561,8 +5562,8 @@ packages:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
 
-  smol-toml@1.6.1:
-    resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
+  smol-toml@1.8.0:
+    resolution: {integrity: sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==}
     engines: {node: '>= 18'}
 
   snake-case@3.0.4:
@@ -7940,7 +7941,7 @@ snapshots:
       pdfjs-dist: 6.2.108
       react: 19.2.4
       semver: 7.8.5
-      smol-toml: 1.6.1
+      smol-toml: 1.8.0
     transitivePeerDependencies:
       - '@types/node'
       - '@types/react'
@@ -10235,7 +10236,7 @@ snapshots:
       jsonwebtoken: 9.0.3
       load-esm: 1.0.3
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.18.0)
+      retry-axios: 2.6.0(axios@1.18.0(debug@4.3.4))
       tough-cookie: 4.1.3
     transitivePeerDependencies:
       - supports-color
@@ -11664,7 +11665,7 @@ snapshots:
 
   ret@0.5.0: {}
 
-  retry-axios@2.6.0(axios@1.18.0):
+  retry-axios@2.6.0(axios@1.18.0(debug@4.3.4)):
     dependencies:
       axios: 1.18.0(debug@4.3.4)
     optional: true
@@ -11950,7 +11951,7 @@ snapshots:
 
   smart-buffer@4.2.0: {}
 
-  smol-toml@1.6.1:
+  smol-toml@1.8.0:
     optional: true
 
   snake-case@3.0.4:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -130,6 +130,8 @@ overrides:
   'gaxios>rimraf': '>=6.1.2'
   # MED CVEs from Scorecard, 2026-09-09 (#1752):
   fflate: '>=0.8.3'                         # GHSA-px8p-9vwx-vf98 (unzipSync infinite loop on malformed ZIP64); only consumer is @openai/codex-security via promptfoo (dev-only), which pinned 0.8.2
+  # HIGH CVE from Dependabot, 2026-09-09:
+  smol-toml: '>=1.7.1'                      # GHSA-7w5x-hrqm-74c2 / CVE-2026-85730 (DoS via malformed TOML); same story as fflate above - only consumer is @openai/codex-security via promptfoo (dev-only), which pins an exact 1.6.1, so nothing but an override moves it
   #
   # Two Scorecard GHSAs deliberately have NO override because no fixed release exists
   # (re-check before assuming they were missed):


### PR DESCRIPTION
Dependabot opened four alerts on 2026-09-09. Only one of them has an upstream fix, and this pins it. The other three are already recorded in `pnpm-workspace.yaml` as deliberately un-overridden because no patched release exists; I re-checked all three and that is still true.

## Fixed here

| Package | Was | Now | Advisory |
| --- | --- | --- | --- |
| `smol-toml` | 1.6.1 | 1.8.0 | [GHSA-7w5x-hrqm-74c2](https://github.com/advisories/GHSA-7w5x-hrqm-74c2) / CVE-2026-85730, denial of service via malformed TOML documents (HIGH) |

Fixed upstream in 1.7.1. The only consumer is `@openai/codex-security` via `promptfoo` (dev-only), and it depends on an exact `"1.6.1"` rather than a range, so no amount of updating moves it. It takes an override. Same shape as the `fflate` pin directly above it in the file.

## Re-checked, still no fix available

| Package | Advisory | Why no override |
| --- | --- | --- |
| `extract-zip` | GHSA-7pqw-9j4j-h8q3, GHSA-jmr9-qjv8-65gv (symlink archive entries, arbitrary file write) | Affect `<=2.0.1`. 2.0.1 is the newest publish and dates from 2023. |
| `adm-zip` | GHSA-vwc7-r8mq-g2x9 (extraction follows destination symlinks, arbitrary file overwrite) | Affects `<=0.6.0`. 0.6.0 is the newest publish. The existing `>=0.6.0` pin is for the unrelated GHSA-xcpc-8h2w-3j85 and has nowhere higher to go. |

No Dependabot ignore entries for those three. An ignore would silence a live advisory; better that the alerts stay open until upstream ships something. Both are archive-extraction bugs on dev-only paths that never process untrusted zips at runtime.

## Note on the lockfile diff

Alongside the `smol-toml` bump, the lockfile normalises one unrelated peer-suffix key (`retry-axios@2.6.0(axios@1.18.0)` becomes `...(axios@1.18.0(debug@4.3.4))`). No version changed; pnpm just writes the more precise form on rewrite.

## Verification

- `pnpm install --frozen-lockfile` passes (lockfile satisfies `minimumReleaseAge` and the trust policy)
- `pnpm typecheck` clean across all four workspace projects
- `pnpm test` 6741 passed / 7 failed

The 7 failures are in `tests/integration/setup-routes.test.ts` and `tests/integration/task-resumable-progress.test.ts`, and are pre-existing rather than caused by this pin:

- both files pass in isolation (30/30)
- the errors are cross-file interference (`DELETE FROM kg_nodes` hitting `contacts_kg_node_id_fkey` that a concurrently-running file inserted) plus one 5s timeout under parallel load
- `setup-routes.test.ts` fails identically on unmodified `main`, checked in a separate clean worktree

`smol-toml` is imported nowhere in `src/` or `tests/`; it reaches the tree only through promptfoo's redteam CLI, so it cannot influence those tests.
