### PR TITLE
fix(calendar): stop advertising RSVP writes Nylas cannot apply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,8 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
-- **`calendar-update-event`** — rejects attendee RSVP status; guest-list replace only; optional notifyAttendees. (#1735)
+- **`calendar-update-event`** — rejects attendee RSVP status on the Nylas path; guest-list replace only. (#1735)
+- **`calendar-create-event`** — same attendee honesty; drops unused colorId and reminders. (#1735)
 - **Dispatcher relay Gate C** — every auto-reply is tier-gated; approve re-delivers via `dispatcher-relay`. (#1733)
 - **Dispatcher no-reply** — `NO_REPLY` ends a turn without publishing `outbound.message`. (#1732)
 - **`NO_REPLY` hardening** — principal declines notify; near-miss and empty replies do not send. (#1732)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **`calendar-update-event`** — rejects attendee RSVP status; guest-list replace only; optional notifyAttendees. (#1735)
 - **Dispatcher relay Gate C** — every auto-reply is tier-gated; approve re-delivers via `dispatcher-relay`. (#1733)
 - **Dispatcher no-reply** — `NO_REPLY` ends a turn without publishing `outbound.message`. (#1732)
 - **`NO_REPLY` hardening** — principal declines notify; near-miss and empty replies do not send. (#1732)

--- a/agents/calendar.yaml
+++ b/agents/calendar.yaml
@@ -1,5 +1,5 @@
 name: calendar
-version: "0.7.0"
+version: "0.7.1"
 role: specialist
 description: >
   Calendar domain specialist — scheduling, free/busy, conflict resolution,
@@ -164,8 +164,13 @@ system_prompt: |
   - For accepts, pass `holdMatchCriteria` and a broad hold search window when
     the consult provides them so all holds associated with the scheduling
     conversation are released, not just the hold overlapping the final invite.
-  - Never update a participants array to RSVP. The RSVP skill uses Nylas
-    sendRsvp so only the principal attendee's own status changes.
+  - Never update a participants array to RSVP — not for the principal, and not
+    to record another guest's reply. Nylas rejects organizer-set participant
+    status on event update; Microsoft Graph cannot set another attendee's
+    response. The RSVP skill uses sendRsvp so only the principal attendee's
+    own status changes. `calendar-update-event` attendees replaces the whole
+    guest list (email + optional name) and re-issues invitations; it cannot
+    patch one person's RSVP.
 
   ## Unregistered Calendar Handling
   When `calendar-list-calendars` surfaces an unregistered calendar during any

--- a/agents/calendar.yaml
+++ b/agents/calendar.yaml
@@ -1,5 +1,5 @@
 name: calendar
-version: "0.7.1"
+version: "0.7.2"
 role: specialist
 description: >
   Calendar domain specialist — scheduling, free/busy, conflict resolution,
@@ -164,13 +164,11 @@ system_prompt: |
   - For accepts, pass `holdMatchCriteria` and a broad hold search window when
     the consult provides them so all holds associated with the scheduling
     conversation are released, not just the hold overlapping the final invite.
-  - Never update a participants array to RSVP — not for the principal, and not
-    to record another guest's reply. Nylas rejects organizer-set participant
-    status on event update; Microsoft Graph cannot set another attendee's
-    response. The RSVP skill uses sendRsvp so only the principal attendee's
-    own status changes. `calendar-update-event` attendees replaces the whole
-    guest list (email + optional name) and re-issues invitations; it cannot
-    patch one person's RSVP.
+  - Never update a participants array to RSVP, and never use
+    `calendar-update-event` to record another guest's RSVP. Use
+    `calendar-respond-to-invite` for the principal's own RSVP.
+    `calendar-update-event` attendees replaces the whole guest list
+    (email + optional name).
 
   ## Unregistered Calendar Handling
   When `calendar-list-calendars` surfaces an unregistered calendar during any

--- a/skills/calendar/tools/calendar-create-event/handler.ts
+++ b/skills/calendar/tools/calendar-create-event/handler.ts
@@ -10,6 +10,7 @@
 
 import type { ToolHandler, ToolContext, ToolResult } from '../../../../src/skills/types.js';
 import type { CreateEventInput } from '../../../../src/channels/calendar/nylas-calendar-client.js';
+import { parseWritableAttendees } from '../../../../src/channels/calendar/attendee-input.js';
 import { toLocalIso, formatDisplayTimezone } from '../../../../src/time/timestamp.js';
 import { isHoldEvent, eventsOverlap } from '../../../../src/channels/calendar/holds.js';
 
@@ -26,7 +27,7 @@ export class CalendarCreateEventHandler implements ToolHandler {
       end?: string;
       description?: string;
       location?: string;
-      attendees?: Array<{ email: string; name?: string }>;
+      attendees?: unknown;
       conferencing?: Record<string, unknown>;
     };
 
@@ -51,8 +52,11 @@ export class CalendarCreateEventHandler implements ToolHandler {
     if (new Date(end) <= new Date(start)) {
       return { success: false, error: 'Invalid input: end must be after start' };
     }
-    if (attendees !== undefined && !Array.isArray(attendees)) {
-      return { success: false, error: 'Invalid input: attendees must be an array' };
+    let parsedAttendees: CreateEventInput['attendees'];
+    if (attendees !== undefined) {
+      const parsed = parseWritableAttendees(attendees);
+      if (!parsed.ok) return { success: false, error: parsed.error };
+      parsedAttendees = parsed.attendees;
     }
 
     try {
@@ -69,7 +73,7 @@ export class CalendarCreateEventHandler implements ToolHandler {
       const eventData: CreateEventInput = { title, start, end };
       if (description) eventData.description = description;
       if (location) eventData.location = location;
-      if (attendees) eventData.attendees = attendees;
+      if (parsedAttendees) eventData.attendees = parsedAttendees;
       if (conferencing) eventData.conferencing = conferencing;
 
       const event = await ctx.nylasCalendarClient.createEvent(calendarId, eventData);

--- a/skills/calendar/tools/calendar-create-event/tool.json
+++ b/skills/calendar/tools/calendar-create-event/tool.json
@@ -1,7 +1,7 @@
 {
   "name": "calendar-create-event",
-  "description": "Create a new calendar event with title, time, attendees, and optional description/location/conferencing. Attendees will receive invitation emails automatically.",
-  "version": "1.0.1",
+  "description": "Create a new calendar event with title, time, and optional description/location/conferencing. attendees is a guest list of { email, name? } — this Nylas tool cannot set RSVP status. Attendees receive invitation emails automatically.",
+  "version": "1.1.0",
   "sensitivity": "normal",
   "action_risk": "high",
   "inputs": {
@@ -11,10 +11,8 @@
     "end": "timestamp (event end time)",
     "description": "string?",
     "location": "string?",
-    "attendees": "object[]?",
-    "conferencing": "object?",
-    "colorId": "string?",
-    "reminders": "object?"
+    "attendees": "object[]? (each { email, name? }. Cannot set RSVP status; use calendar-respond-to-invite for the principal's own RSVP.)",
+    "conferencing": "object?"
   },
   "outputs": {
     "event": "object"

--- a/skills/calendar/tools/calendar-update-event/handler.ts
+++ b/skills/calendar/tools/calendar-update-event/handler.ts
@@ -4,63 +4,17 @@
 // Checks the read-only flag before attempting the update.
 //
 // Guest-list writes replace the entire attendee array (email + optional name).
-// Organizer-set RSVP status is not supported: Nylas rejects it on PUT, and
-// Microsoft Graph cannot set another attendee's response. First-person RSVP
-// is calendar-respond-to-invite (sendRsvp).
+// This Nylas tool does not set RSVP status; first-person RSVP is
+// calendar-respond-to-invite (sendRsvp).
 
 import type { ToolHandler, ToolContext, ToolResult } from '../../../../src/skills/types.js';
-import type { CalendarAttendeeInput, CreateEventInput } from '../../../../src/channels/calendar/nylas-calendar-client.js';
+import type { CreateEventInput } from '../../../../src/channels/calendar/nylas-calendar-client.js';
+import {
+  parseWritableAttendees,
+  collectGuestListMismatches,
+  guestListMismatchWarnings,
+} from '../../../../src/channels/calendar/attendee-input.js';
 import { toLocalIso, formatDisplayTimezone } from '../../../../src/time/timestamp.js';
-
-const RSVP_STATUS_KEYS = ['status', 'responseStatus', 'participationStatus'] as const;
-
-const ATTENDEE_STATUS_UNSUPPORTED =
-  'Attendee response status cannot be set through calendar-update-event. ' +
-  'Nylas rejects organizer-set participant status on event update; Microsoft Graph cannot set another attendee\'s response; ' +
-  'only the authenticated principal can RSVP, via calendar-respond-to-invite. ' +
-  'Pass attendees as email and optional name to replace the guest list.';
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
-function parseAttendees(raw: unknown): { ok: true; attendees: CalendarAttendeeInput[] } | { ok: false; error: string } {
-  if (!Array.isArray(raw)) {
-    return { ok: false, error: 'Invalid input: attendees must be an array' };
-  }
-  const attendees: CalendarAttendeeInput[] = [];
-  for (const item of raw) {
-    if (!isRecord(item)) {
-      return { ok: false, error: 'Invalid input: each attendee must be an object with email and optional name' };
-    }
-    if (RSVP_STATUS_KEYS.some((key) => key in item)) {
-      return { ok: false, error: ATTENDEE_STATUS_UNSUPPORTED };
-    }
-    if (typeof item.email !== 'string' || item.email.trim() === '') {
-      return { ok: false, error: 'Invalid input: each attendee must have a non-empty email' };
-    }
-    if (item.name !== undefined && typeof item.name !== 'string') {
-      return { ok: false, error: 'Invalid input: attendee name must be a string when provided' };
-    }
-    const attendee: CalendarAttendeeInput = { email: item.email.trim() };
-    if (typeof item.name === 'string') attendee.name = item.name;
-    attendees.push(attendee);
-  }
-  return { ok: true, attendees };
-}
-
-function missingRequestedEmails(
-  requested: CalendarAttendeeInput[],
-  returned: Array<{ email: string }>,
-): string[] {
-  const returnedSet = new Set(returned.map((p) => p.email.trim().toLowerCase()));
-  const missing: string[] = [];
-  for (const attendee of requested) {
-    const email = attendee.email.trim().toLowerCase();
-    if (!returnedSet.has(email)) missing.push(email);
-  }
-  return missing;
-}
 
 export class CalendarUpdateEventHandler implements ToolHandler {
   async execute(ctx: ToolContext): Promise<ToolResult> {
@@ -113,7 +67,7 @@ export class CalendarUpdateEventHandler implements ToolHandler {
       if (description !== undefined) changes.description = description;
       if (location !== undefined) changes.location = location;
       if (attendees !== undefined) {
-        const parsed = parseAttendees(attendees);
+        const parsed = parseWritableAttendees(attendees);
         if (!parsed.ok) return { success: false, error: parsed.error };
         changes.attendees = parsed.attendees;
       }
@@ -131,32 +85,27 @@ export class CalendarUpdateEventHandler implements ToolHandler {
         notifyAttendees,
       );
 
+      const warnings: string[] = [];
       if (changes.attendees) {
-        const missing = missingRequestedEmails(changes.attendees, event.participants);
-        if (missing.length > 0) {
-          ctx.log.error(
-            { calendarId, eventId, missingCount: missing.length },
-            'calendar-update-event: provider response omitted requested attendees',
+        const { missing, extra } = collectGuestListMismatches(changes.attendees, event.participants);
+        warnings.push(...guestListMismatchWarnings(missing, extra));
+        if (missing.length > 0 || extra.length > 0) {
+          ctx.log.warn(
+            { calendarId, eventId, missingCount: missing.length, extraCount: extra.length },
+            'calendar-update-event: provider guest list did not match the request',
           );
-          return {
-            success: false,
-            error:
-              `Failed to update event: provider response did not include ${missing.length} requested attendee(s). ` +
-              'The guest list replace may not have applied. Re-read the event before retrying.',
-          };
         }
+      }
+      if (notifyAttendees === false) {
+        warnings.push(
+          'notifyAttendees=false is honoured by Google Calendar; Microsoft and iCloud ignore it and still email attendees.',
+        );
       }
 
       ctx.log.info({ calendarId, eventId }, 'Updated calendar event');
       // Format timestamps in the user's local timezone so the confirmation matches
       // what calendar-list-events returns. toLocalIso handles null/invalid values internally.
       const tz = ctx.timezone;
-      const warnings: string[] = [];
-      if (notifyAttendees === false) {
-        warnings.push(
-          'notifyAttendees=false is honoured by Google Calendar; Microsoft and iCloud ignore it and still email attendees.',
-        );
-      }
       return {
         success: true,
         data: {

--- a/skills/calendar/tools/calendar-update-event/handler.ts
+++ b/skills/calendar/tools/calendar-update-event/handler.ts
@@ -2,9 +2,65 @@
 //
 // Updates an existing calendar event with partial field changes.
 // Checks the read-only flag before attempting the update.
+//
+// Guest-list writes replace the entire attendee array (email + optional name).
+// Organizer-set RSVP status is not supported: Nylas rejects it on PUT, and
+// Microsoft Graph cannot set another attendee's response. First-person RSVP
+// is calendar-respond-to-invite (sendRsvp).
 
 import type { ToolHandler, ToolContext, ToolResult } from '../../../../src/skills/types.js';
+import type { CalendarAttendeeInput, CreateEventInput } from '../../../../src/channels/calendar/nylas-calendar-client.js';
 import { toLocalIso, formatDisplayTimezone } from '../../../../src/time/timestamp.js';
+
+const RSVP_STATUS_KEYS = ['status', 'responseStatus', 'participationStatus'] as const;
+
+const ATTENDEE_STATUS_UNSUPPORTED =
+  'Attendee response status cannot be set through calendar-update-event. ' +
+  'Nylas rejects organizer-set participant status on event update; Microsoft Graph cannot set another attendee\'s response; ' +
+  'only the authenticated principal can RSVP, via calendar-respond-to-invite. ' +
+  'Pass attendees as email and optional name to replace the guest list.';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function parseAttendees(raw: unknown): { ok: true; attendees: CalendarAttendeeInput[] } | { ok: false; error: string } {
+  if (!Array.isArray(raw)) {
+    return { ok: false, error: 'Invalid input: attendees must be an array' };
+  }
+  const attendees: CalendarAttendeeInput[] = [];
+  for (const item of raw) {
+    if (!isRecord(item)) {
+      return { ok: false, error: 'Invalid input: each attendee must be an object with email and optional name' };
+    }
+    if (RSVP_STATUS_KEYS.some((key) => key in item)) {
+      return { ok: false, error: ATTENDEE_STATUS_UNSUPPORTED };
+    }
+    if (typeof item.email !== 'string' || item.email.trim() === '') {
+      return { ok: false, error: 'Invalid input: each attendee must have a non-empty email' };
+    }
+    if (item.name !== undefined && typeof item.name !== 'string') {
+      return { ok: false, error: 'Invalid input: attendee name must be a string when provided' };
+    }
+    const attendee: CalendarAttendeeInput = { email: item.email.trim() };
+    if (typeof item.name === 'string') attendee.name = item.name;
+    attendees.push(attendee);
+  }
+  return { ok: true, attendees };
+}
+
+function missingRequestedEmails(
+  requested: CalendarAttendeeInput[],
+  returned: Array<{ email: string }>,
+): string[] {
+  const returnedSet = new Set(returned.map((p) => p.email.trim().toLowerCase()));
+  const missing: string[] = [];
+  for (const attendee of requested) {
+    const email = attendee.email.trim().toLowerCase();
+    if (!returnedSet.has(email)) missing.push(email);
+  }
+  return missing;
+}
 
 export class CalendarUpdateEventHandler implements ToolHandler {
   async execute(ctx: ToolContext): Promise<ToolResult> {
@@ -12,7 +68,7 @@ export class CalendarUpdateEventHandler implements ToolHandler {
       return { success: false, error: 'Calendar not configured — Nylas credentials missing' };
     }
 
-    const { calendarId, eventId, title, start, end, description, location, attendees, conferencing } = ctx.input as {
+    const { calendarId, eventId, title, start, end, description, location, attendees, conferencing, notifyAttendees } = ctx.input as {
       calendarId?: string;
       eventId?: string;
       title?: string;
@@ -20,8 +76,9 @@ export class CalendarUpdateEventHandler implements ToolHandler {
       end?: string;
       description?: string;
       location?: string;
-      attendees?: Array<{ email: string; name?: string }>;
+      attendees?: unknown;
       conferencing?: Record<string, unknown>;
+      notifyAttendees?: unknown;
     };
 
     if (!calendarId || typeof calendarId !== 'string') {
@@ -29,6 +86,9 @@ export class CalendarUpdateEventHandler implements ToolHandler {
     }
     if (!eventId || typeof eventId !== 'string') {
       return { success: false, error: 'Missing required input: eventId' };
+    }
+    if (notifyAttendees !== undefined && typeof notifyAttendees !== 'boolean') {
+      return { success: false, error: 'Invalid input: notifyAttendees must be a boolean' };
     }
 
     try {
@@ -40,7 +100,7 @@ export class CalendarUpdateEventHandler implements ToolHandler {
         }
       }
 
-      const changes: Record<string, unknown> = {};
+      const changes: Partial<CreateEventInput> = {};
       if (title !== undefined) changes.title = title;
       if (start !== undefined) {
         if (!start) return { success: false, error: 'Invalid input: start must be a non-empty string' };
@@ -53,8 +113,9 @@ export class CalendarUpdateEventHandler implements ToolHandler {
       if (description !== undefined) changes.description = description;
       if (location !== undefined) changes.location = location;
       if (attendees !== undefined) {
-        if (!Array.isArray(attendees)) return { success: false, error: 'Invalid input: attendees must be an array' };
-        changes.attendees = attendees;
+        const parsed = parseAttendees(attendees);
+        if (!parsed.ok) return { success: false, error: parsed.error };
+        changes.attendees = parsed.attendees;
       }
       if (conferencing !== undefined) changes.conferencing = conferencing;
 
@@ -63,11 +124,39 @@ export class CalendarUpdateEventHandler implements ToolHandler {
         return { success: false, error: 'No fields provided to update — at least one of title, start, end, description, location, attendees, or conferencing is required' };
       }
 
-      const event = await ctx.nylasCalendarClient.updateEvent(calendarId, eventId, changes);
+      const event = await ctx.nylasCalendarClient.updateEvent(
+        calendarId,
+        eventId,
+        changes,
+        notifyAttendees,
+      );
+
+      if (changes.attendees) {
+        const missing = missingRequestedEmails(changes.attendees, event.participants);
+        if (missing.length > 0) {
+          ctx.log.error(
+            { calendarId, eventId, missingCount: missing.length },
+            'calendar-update-event: provider response omitted requested attendees',
+          );
+          return {
+            success: false,
+            error:
+              `Failed to update event: provider response did not include ${missing.length} requested attendee(s). ` +
+              'The guest list replace may not have applied. Re-read the event before retrying.',
+          };
+        }
+      }
+
       ctx.log.info({ calendarId, eventId }, 'Updated calendar event');
       // Format timestamps in the user's local timezone so the confirmation matches
       // what calendar-list-events returns. toLocalIso handles null/invalid values internally.
       const tz = ctx.timezone;
+      const warnings: string[] = [];
+      if (notifyAttendees === false) {
+        warnings.push(
+          'notifyAttendees=false is honoured by Google Calendar; Microsoft and iCloud ignore it and still email attendees.',
+        );
+      }
       return {
         success: true,
         data: {
@@ -77,6 +166,7 @@ export class CalendarUpdateEventHandler implements ToolHandler {
             endTime: toLocalIso(event.endTime, tz),
           },
           displayTimezone: tz ? formatDisplayTimezone(tz, new Date()) : null,
+          ...(warnings.length > 0 ? { warnings } : {}),
         },
       };
     } catch (err) {

--- a/skills/calendar/tools/calendar-update-event/tool.json
+++ b/skills/calendar/tools/calendar-update-event/tool.json
@@ -1,7 +1,7 @@
 {
   "name": "calendar-update-event",
-  "description": "Modify an existing calendar event. Supports partial updates — only provide the fields that need changing (title, time, description, location, attendees, conferencing). Attendee changes trigger invitation updates.",
-  "version": "1.0.0",
+  "description": "Modify an existing calendar event. Partial updates: send only the fields that change (title, start, end, description, location, attendees, conferencing). attendees replaces the entire guest list with email and optional name — not a per-person patch, and it cannot set RSVP status (Nylas rejects organizer-set participant status; Microsoft Graph cannot set another attendee's response). Use calendar-respond-to-invite for the principal's own RSVP. Guest-list and time changes send invitation emails by default. Set notifyAttendees=false to suppress those emails on Google; Microsoft and iCloud always notify.",
+  "version": "1.1.0",
   "sensitivity": "normal",
   "action_risk": "high",
   "inputs": {
@@ -12,13 +12,13 @@
     "end": "timestamp? (new event end time)",
     "description": "string?",
     "location": "string?",
-    "attendees": "object[]? (list of attendees to set, each with email and optional name)",
+    "attendees": "object[]? (full guest-list replacement: each { email, name? }. Cannot set RSVP status. Replaces every attendee, it does not patch one.)",
     "conferencing": "object?",
-    "colorId": "string?",
-    "reminders": "object?"
+    "notifyAttendees": "boolean? (default true. false suppresses invitation emails on Google only; Microsoft and iCloud always notify.)"
   },
   "outputs": {
-    "event": "object"
+    "event": "object",
+    "warnings": "string[]? (present when notifyAttendees=false, noting Microsoft/iCloud still notify)"
   },
   "permissions": [],
   "secrets": [],

--- a/skills/calendar/tools/calendar-update-event/tool.json
+++ b/skills/calendar/tools/calendar-update-event/tool.json
@@ -1,6 +1,6 @@
 {
   "name": "calendar-update-event",
-  "description": "Modify an existing calendar event. Partial updates: send only the fields that change (title, start, end, description, location, attendees, conferencing). attendees replaces the entire guest list with email and optional name — not a per-person patch, and it cannot set RSVP status (Nylas rejects organizer-set participant status; Microsoft Graph cannot set another attendee's response). Use calendar-respond-to-invite for the principal's own RSVP. Guest-list and time changes send invitation emails by default. Set notifyAttendees=false to suppress those emails on Google; Microsoft and iCloud always notify.",
+  "description": "Modify an existing calendar event. Partial updates: send only the fields that change (title, start, end, description, location, attendees, conferencing). attendees replaces the entire guest list with email and optional name — not a per-person patch, and this Nylas tool cannot set RSVP status (use calendar-respond-to-invite for the principal's own RSVP). Whether existing RSVPs are preserved on a guest-list replace is unverified; re-read the event after changing attendees. Guest-list and time changes send invitation emails by default. Set notifyAttendees=false to suppress those emails on Google; Microsoft and iCloud always notify.",
   "version": "1.1.0",
   "sensitivity": "normal",
   "action_risk": "high",
@@ -12,13 +12,13 @@
     "end": "timestamp? (new event end time)",
     "description": "string?",
     "location": "string?",
-    "attendees": "object[]? (full guest-list replacement: each { email, name? }. Cannot set RSVP status. Replaces every attendee, it does not patch one.)",
+    "attendees": "object[]? (full guest-list replacement: each { email, name? }. Cannot set RSVP status. Replaces membership; RSVP preservation on retained guests is unverified — re-read after writing.)",
     "conferencing": "object?",
     "notifyAttendees": "boolean? (default true. false suppresses invitation emails on Google only; Microsoft and iCloud always notify.)"
   },
   "outputs": {
     "event": "object",
-    "warnings": "string[]? (present when notifyAttendees=false, noting Microsoft/iCloud still notify)"
+    "warnings": "string[]? (notifyAttendees=false caveat, and guest-list mismatches after a write that already applied)"
   },
   "permissions": [],
   "secrets": [],

--- a/src/channels/calendar/attendee-input.test.ts
+++ b/src/channels/calendar/attendee-input.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseWritableAttendees,
+  collectGuestListMismatches,
+  guestListMismatchWarnings,
+  ATTENDEE_STATUS_UNSUPPORTED,
+} from './attendee-input.js';
+
+describe('parseWritableAttendees', () => {
+  it('accepts email and optional name', () => {
+    const parsed = parseWritableAttendees([
+      { email: ' a@example.test ', name: 'A' },
+      { email: 'b@example.test' },
+    ]);
+    expect(parsed).toEqual({
+      ok: true,
+      attendees: [
+        { email: 'a@example.test', name: 'A' },
+        { email: 'b@example.test' },
+      ],
+    });
+  });
+
+  it('rejects RSVP status fields', () => {
+    const parsed = parseWritableAttendees([{ email: 'a@example.test', status: 'yes' }]);
+    expect(parsed).toEqual({ ok: false, error: ATTENDEE_STATUS_UNSUPPORTED });
+  });
+});
+
+describe('collectGuestListMismatches', () => {
+  it('does not throw when a returned participant has no email', () => {
+    expect(() => collectGuestListMismatches(
+      [{ email: 'a@example.test' }],
+      [{ email: 'a@example.test' }, { email: undefined }, { email: null }],
+    )).not.toThrow();
+  });
+
+  it('reports missing requested emails and extra returned emails', () => {
+    expect(collectGuestListMismatches(
+      [{ email: 'a@example.test' }, { email: 'b@example.test' }],
+      [{ email: 'a@example.test' }, { email: 'organizer@example.test' }],
+    )).toEqual({
+      missing: ['b@example.test'],
+      extra: ['organizer@example.test'],
+    });
+  });
+});
+
+describe('guestListMismatchWarnings', () => {
+  it('tells the caller the write already applied', () => {
+    const warnings = guestListMismatchWarnings(['b@example.test'], ['organizer@example.test']);
+    expect(warnings).toHaveLength(2);
+    expect(warnings[0]).toMatch(/already applied/i);
+    expect(warnings[1]).toMatch(/do not retry/i);
+  });
+});

--- a/src/channels/calendar/attendee-input.ts
+++ b/src/channels/calendar/attendee-input.ts
@@ -1,0 +1,87 @@
+// attendee-input.ts — shared guest-list parsing for Nylas calendar writes.
+//
+// Attendees on create/update are membership only (email + optional name).
+// RSVP status is not a writable field on this path; first-person RSVP is sendRsvp.
+
+/** Guest-list entry for create/update. RSVP `status` is intentionally absent. */
+export interface CalendarAttendeeInput {
+  email: string;
+  name?: string;
+}
+
+export const ATTENDEE_RSVP_STATUS_KEYS = ['status', 'responseStatus', 'participationStatus'] as const;
+
+export const ATTENDEE_STATUS_UNSUPPORTED =
+  'Attendee response status cannot be set through this Nylas calendar tool. ' +
+  'Pass attendees as email and optional name only. For the principal\'s own RSVP, use calendar-respond-to-invite.';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function parseWritableAttendees(
+  raw: unknown,
+): { ok: true; attendees: CalendarAttendeeInput[] } | { ok: false; error: string } {
+  if (!Array.isArray(raw)) {
+    return { ok: false, error: 'Invalid input: attendees must be an array' };
+  }
+  const attendees: CalendarAttendeeInput[] = [];
+  for (const item of raw) {
+    if (!isRecord(item)) {
+      return { ok: false, error: 'Invalid input: each attendee must be an object with email and optional name' };
+    }
+    if (ATTENDEE_RSVP_STATUS_KEYS.some((key) => key in item)) {
+      return { ok: false, error: ATTENDEE_STATUS_UNSUPPORTED };
+    }
+    if (typeof item.email !== 'string' || item.email.trim() === '') {
+      return { ok: false, error: 'Invalid input: each attendee must have a non-empty email' };
+    }
+    if (item.name !== undefined && typeof item.name !== 'string') {
+      return { ok: false, error: 'Invalid input: attendee name must be a string when provided' };
+    }
+    const attendee: CalendarAttendeeInput = { email: item.email.trim() };
+    if (typeof item.name === 'string') attendee.name = item.name;
+    attendees.push(attendee);
+  }
+  return { ok: true, attendees };
+}
+
+function normalizedEmail(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim().toLowerCase();
+  return trimmed === '' ? null : trimmed;
+}
+
+/** Compare requested guest emails to the provider response. Skips participants with no email (rooms/resources). */
+export function collectGuestListMismatches(
+  requested: CalendarAttendeeInput[],
+  returned: Array<{ email?: string | null }>,
+): { missing: string[]; extra: string[] } {
+  const returnedEmails = returned
+    .map((p) => normalizedEmail(p.email))
+    .filter((email): email is string => email !== null);
+  const returnedSet = new Set(returnedEmails);
+  const requestedEmails = requested
+    .map((a) => normalizedEmail(a.email))
+    .filter((email): email is string => email !== null);
+  const requestedSet = new Set(requestedEmails);
+
+  const missing = requestedEmails.filter((email) => !returnedSet.has(email));
+  const extra = returnedEmails.filter((email) => !requestedSet.has(email));
+  return { missing, extra };
+}
+
+export function guestListMismatchWarnings(missing: string[], extra: string[]): string[] {
+  const warnings: string[] = [];
+  if (missing.length > 0) {
+    warnings.push(
+      `Provider response omitted ${missing.length} requested attendee(s). The write already applied; do not retry. Re-read the event.`,
+    );
+  }
+  if (extra.length > 0) {
+    warnings.push(
+      `Provider response included ${extra.length} extra participant(s) that were not requested (often the organizer). The write already applied; do not retry. Re-read the event.`,
+    );
+  }
+  return warnings;
+}

--- a/src/channels/calendar/nylas-calendar-client.test.ts
+++ b/src/channels/calendar/nylas-calendar-client.test.ts
@@ -97,6 +97,70 @@ describe('NylasCalendarClient — metadata/status/busy plumbing', () => {
   });
 });
 
+describe('NylasCalendarClient — updateEvent attendee writes', () => {
+  it('sends the full guest list as email and name and omits participant status', async () => {
+    const update = vi.fn().mockResolvedValue({
+      data: {
+        id: 'evt_1',
+        participants: [
+          { email: 'a@example.test', name: 'A', status: 'noreply' },
+          { email: 'b@example.test', name: 'B', status: 'yes' },
+        ],
+        when: { startTime: 1000, endTime: 2000 },
+      },
+    });
+    const client = makeClientWith({ events: { update } as unknown as NylasCalendarLike['events'] });
+
+    await client.updateEvent('cal_1', 'evt_1', {
+      attendees: [
+        { email: 'a@example.test', name: 'A' },
+        { email: 'b@example.test', name: 'B' },
+      ],
+    });
+
+    const call = update.mock.calls[0]![0] as {
+      requestBody: { participants: Array<Record<string, unknown>> };
+      queryParams: Record<string, unknown>;
+    };
+    expect(call.requestBody.participants).toEqual([
+      { email: 'a@example.test', name: 'A' },
+      { email: 'b@example.test', name: 'B' },
+    ]);
+    for (const participant of call.requestBody.participants) {
+      expect(participant).not.toHaveProperty('status');
+    }
+    expect(call.queryParams).toEqual({ calendar_id: 'cal_1' });
+  });
+
+  it('throws rather than forwarding organizer-set participant status', async () => {
+    const update = vi.fn();
+    const client = makeClientWith({ events: { update } as unknown as NylasCalendarLike['events'] });
+
+    await expect(
+      client.updateEvent('cal_1', 'evt_1', {
+        attendees: [{ email: 'a@example.test', name: 'A', status: 'no' } as { email: string; name: string }],
+      }),
+    ).rejects.toThrow(/sendRsvp/i);
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('sets notify_participants when notifyAttendees is provided', async () => {
+    const update = vi.fn().mockResolvedValue({
+      data: { id: 'evt_1', when: { startTime: 1000, endTime: 2000 } },
+    });
+    const client = makeClientWith({ events: { update } as unknown as NylasCalendarLike['events'] });
+
+    await client.updateEvent('cal_1', 'evt_1', { title: 'Quiet' }, false);
+
+    expect(update).toHaveBeenCalledWith({
+      identifier: 'grant_test',
+      eventId: 'evt_1',
+      queryParams: { calendar_id: 'cal_1', notify_participants: false },
+      requestBody: { title: 'Quiet' },
+    });
+  });
+});
+
 describe('NylasCalendarClient — RSVP plumbing', () => {
   it('sends RSVP status through the Nylas sendRsvp endpoint', async () => {
     const sendRsvp = vi.fn().mockResolvedValue({

--- a/src/channels/calendar/nylas-calendar-client.ts
+++ b/src/channels/calendar/nylas-calendar-client.ts
@@ -9,6 +9,10 @@
 
 import NylasDefault from 'nylas';
 import type { Logger } from '../../logger.js';
+import { ATTENDEE_RSVP_STATUS_KEYS } from './attendee-input.js';
+import type { CalendarAttendeeInput } from './attendee-input.js';
+
+export type { CalendarAttendeeInput } from './attendee-input.js';
 
 /**
  * Minimal typed interface for the Nylas SDK calendar surface.
@@ -184,14 +188,6 @@ export type NylasRsvpStatus = 'yes' | 'no' | 'maybe';
 export interface NylasRsvpResult {
   requestId: string | null;
   sendIcsError: unknown | null;
-}
-
-/** Guest-list entry for create/update. RSVP `status` is intentionally absent:
- *  Nylas rejects organizer-set participant status on PUT ("Updating the status
- *  for participants is not allowed"). First-person RSVP is `sendRsvp` only. */
-export interface CalendarAttendeeInput {
-  email: string;
-  name?: string;
 }
 
 export interface CreateEventInput {
@@ -493,19 +489,29 @@ export class NylasCalendarClient {
   /**
    * Map Curia attendees to the Nylas write shape (email + name only).
    *
-   * Nylas `Participant.status` is required on the *read* type and reused on
-   * Create/UpdateEventRequest, but sending it on PUT is rejected:
-   * "Updating the status for participants is not allowed, only participants
-   * can rsvp or change the status of an event". Google Calendar can write
-   * `attendees[].responseStatus` as organizer; Microsoft Graph cannot; Nylas
-   * fails closed for both. First-person RSVP is `sendRsvp`.
+   * Why status is omitted (Nylas path, not a live PUT in this repo):
+   * - Nylas support (updated 2024-04-24) documents PUT /events rejecting
+   *   organizer-set participant status with
+   *   "Updating the status for participants is not allowed, only participants
+   *   can rsvp or change the status of an event":
+   *   https://support.nylas.com/hc/en-us/articles/4429255774865-Updating-the-status-for-participants-is-not-allowed-only-participants-can-rsvp-or-change-the-status-of-an-event
+   *   That article is v2-shaped (`PUT /events`); it has not been re-verified
+   *   against v3 on a live grant here.
+   * - v3 send-rsvp is the documented RSVP write:
+   *   https://developer.nylas.com/docs/reference/api/events/send-rsvp/
+   * - v3 PUT example participants are email/name/comment only (no status):
+   *   https://developer.nylas.com/docs/reference/api/events/put-events-id/
+   *
+   * Google Calendar API can write attendees[].responseStatus as organizer; that
+   * is a different integration than this Nylas client. First-person RSVP here
+   * is sendRsvp.
    */
   private toWritableParticipants(
     attendees: CalendarAttendeeInput[],
   ): Array<{ email: string; name: string }> {
     return attendees.map((a) => {
       const extra = a as unknown as Record<string, unknown>;
-      if ('status' in extra || 'responseStatus' in extra || 'participationStatus' in extra) {
+      if (ATTENDEE_RSVP_STATUS_KEYS.some((key) => key in extra)) {
         throw new Error(
           'Cannot set attendee response status on create/update; Nylas allows RSVP only via sendRsvp',
         );

--- a/src/channels/calendar/nylas-calendar-client.ts
+++ b/src/channels/calendar/nylas-calendar-client.ts
@@ -186,13 +186,21 @@ export interface NylasRsvpResult {
   sendIcsError: unknown | null;
 }
 
+/** Guest-list entry for create/update. RSVP `status` is intentionally absent:
+ *  Nylas rejects organizer-set participant status on PUT ("Updating the status
+ *  for participants is not allowed"). First-person RSVP is `sendRsvp` only. */
+export interface CalendarAttendeeInput {
+  email: string;
+  name?: string;
+}
+
 export interface CreateEventInput {
   title: string;
   start: string;
   end: string;
   description?: string;
   location?: string;
-  attendees?: Array<{ email: string; name?: string }>;
+  attendees?: CalendarAttendeeInput[];
   conferencing?: Record<string, unknown>;
   /** Arbitrary string key/value pairs to attach to the event (e.g. `{ "curia-hold": "true" }`). Values must be strings (Nylas requirement). */
   metadata?: Record<string, string>;
@@ -315,10 +323,7 @@ export class NylasCalendarClient {
       if (event.description) requestBody.description = event.description;
       if (event.location) requestBody.location = event.location;
       if (event.attendees) {
-        requestBody.participants = event.attendees.map((a) => ({
-          email: a.email,
-          name: a.name ?? '',
-        }));
+        requestBody.participants = this.toWritableParticipants(event.attendees);
       }
       if (event.conferencing) requestBody.conferencing = event.conferencing;
       // Conditionally include metadata/status/busy so existing create calls are byte-for-byte unchanged.
@@ -338,13 +343,21 @@ export class NylasCalendarClient {
     }
   }
 
-  /** Update an existing event. */
+  /**
+   * Update an existing event.
+   *
+   * `notifyAttendees` maps to Nylas `notify_participants`. Default (omit) is
+   * provider-true: Google emails guests; Microsoft and iCloud always notify and
+   * ignore `false`. Guest-list writes replace the entire `participants` array
+   * (Nylas PUT nested-object replace) with email/name only — never RSVP status.
+   */
   async updateEvent(
     calendarId: string,
     eventId: string,
     changes: Partial<CreateEventInput>,
+    notifyAttendees?: boolean,
   ): Promise<NylasCalendarEvent> {
-    this.log.debug({ calendarId, eventId }, 'Updating event');
+    this.log.debug({ calendarId, eventId, notifyAttendees }, 'Updating event');
     try {
       const requestBody: Record<string, unknown> = {};
       if (changes.title !== undefined) requestBody.title = changes.title;
@@ -357,10 +370,7 @@ export class NylasCalendarClient {
         };
       }
       if (changes.attendees) {
-        requestBody.participants = changes.attendees.map((a) => ({
-          email: a.email,
-          name: a.name ?? '',
-        }));
+        requestBody.participants = this.toWritableParticipants(changes.attendees);
       }
       if (changes.conferencing !== undefined) requestBody.conferencing = changes.conferencing;
       // Conditionally include metadata/status/busy so existing update calls are byte-for-byte unchanged.
@@ -368,10 +378,15 @@ export class NylasCalendarClient {
       if (changes.status) requestBody.status = changes.status;
       if (typeof changes.busy === 'boolean') requestBody.busy = changes.busy;
 
+      const queryParams: Record<string, unknown> = { calendar_id: calendarId };
+      if (notifyAttendees !== undefined) {
+        queryParams.notify_participants = notifyAttendees;
+      }
+
       const response = await this.nylas.events.update({
         identifier: this.grantId,
         eventId,
-        queryParams: { calendar_id: calendarId },
+        queryParams,
         requestBody,
       });
       return this.normalizeEvent(response.data);
@@ -474,6 +489,30 @@ export class NylasCalendarClient {
   }
 
   // -- Helpers --
+
+  /**
+   * Map Curia attendees to the Nylas write shape (email + name only).
+   *
+   * Nylas `Participant.status` is required on the *read* type and reused on
+   * Create/UpdateEventRequest, but sending it on PUT is rejected:
+   * "Updating the status for participants is not allowed, only participants
+   * can rsvp or change the status of an event". Google Calendar can write
+   * `attendees[].responseStatus` as organizer; Microsoft Graph cannot; Nylas
+   * fails closed for both. First-person RSVP is `sendRsvp`.
+   */
+  private toWritableParticipants(
+    attendees: CalendarAttendeeInput[],
+  ): Array<{ email: string; name: string }> {
+    return attendees.map((a) => {
+      const extra = a as unknown as Record<string, unknown>;
+      if ('status' in extra || 'responseStatus' in extra || 'participationStatus' in extra) {
+        throw new Error(
+          'Cannot set attendee response status on create/update; Nylas allows RSVP only via sendRsvp',
+        );
+      }
+      return { email: a.email, name: a.name ?? '' };
+    });
+  }
 
   /** Convert an ISO 8601 string to Unix seconds, throwing on unparseable input. */
   private toUnixSeconds(iso: string, label: string): number {

--- a/tests/unit/agents/calendar-prompt.test.ts
+++ b/tests/unit/agents/calendar-prompt.test.ts
@@ -256,7 +256,21 @@ describe('calendar agent — key-loaded scheduling rules (ceo-inbox parity)', ()
   it('bumps calendar agent version for scheduling-rules capability', async () => {
     const config = loadAgentConfig(path.join(agentsDir, 'calendar.yaml'));
     // Exact-version tripwire: bump this alongside `agents/calendar.yaml`'s version on any
-    // meaningful prompt/capability change. 0.7.0 = pin calendar skill bundle (#1489).
-    expect(config.version).toBe('0.7.0');
+    // meaningful prompt/capability change. 0.7.1 = calendar-update-event cannot set RSVP status (#1735).
+    expect(config.version).toBe('0.7.1');
+  });
+
+  it('forbids using calendar-update-event to record another guest RSVP', () => {
+    const prompt = loadCalendarPrompt();
+    const rsvpStart = prompt.indexOf('RSVP policy:');
+    const rsvpEnd = prompt.indexOf('## Unregistered Calendar Handling');
+    expect(rsvpStart).toBeGreaterThan(-1);
+    expect(rsvpEnd).toBeGreaterThan(rsvpStart);
+    const rsvpSection = prompt.slice(rsvpStart, rsvpEnd);
+    expect(rsvpSection).toContain('Never update a participants array to RSVP');
+    expect(rsvpSection).toContain('Nylas rejects organizer-set participant');
+    expect(rsvpSection).toContain('calendar-update-event');
+    expect(rsvpSection).toContain('cannot');
+    expect(rsvpSection).toMatch(/patch one person's RSVP/i);
   });
 });

--- a/tests/unit/agents/calendar-prompt.test.ts
+++ b/tests/unit/agents/calendar-prompt.test.ts
@@ -256,8 +256,8 @@ describe('calendar agent — key-loaded scheduling rules (ceo-inbox parity)', ()
   it('bumps calendar agent version for scheduling-rules capability', async () => {
     const config = loadAgentConfig(path.join(agentsDir, 'calendar.yaml'));
     // Exact-version tripwire: bump this alongside `agents/calendar.yaml`'s version on any
-    // meaningful prompt/capability change. 0.7.1 = calendar-update-event cannot set RSVP status (#1735).
-    expect(config.version).toBe('0.7.1');
+    // meaningful prompt/capability change. 0.7.2 = RSVP prompt no longer states unverified vendor claims (#1735).
+    expect(config.version).toBe('0.7.2');
   });
 
   it('forbids using calendar-update-event to record another guest RSVP', () => {
@@ -268,9 +268,9 @@ describe('calendar agent — key-loaded scheduling rules (ceo-inbox parity)', ()
     expect(rsvpEnd).toBeGreaterThan(rsvpStart);
     const rsvpSection = prompt.slice(rsvpStart, rsvpEnd);
     expect(rsvpSection).toContain('Never update a participants array to RSVP');
-    expect(rsvpSection).toContain('Nylas rejects organizer-set participant');
     expect(rsvpSection).toContain('calendar-update-event');
-    expect(rsvpSection).toContain('cannot');
-    expect(rsvpSection).toMatch(/patch one person's RSVP/i);
+    expect(rsvpSection).toContain('calendar-respond-to-invite');
+    expect(rsvpSection).not.toMatch(/Nylas rejects organizer-set/i);
+    expect(rsvpSection).not.toMatch(/Microsoft Graph cannot/i);
   });
 });

--- a/tests/unit/channels/nylas-calendar-client.test.ts
+++ b/tests/unit/channels/nylas-calendar-client.test.ts
@@ -214,6 +214,33 @@ describe('NylasCalendarClient', () => {
         }),
       });
     });
+
+    it('maps attendees to email/name only and sets notify_participants', async () => {
+      await client.updateEvent(
+        'cal-1',
+        'evt-1',
+        { attendees: [{ email: 'a@example.test', name: 'A' }, { email: 'b@example.test' }] },
+        false,
+      );
+
+      expect(sdk.events.update).toHaveBeenCalledWith({
+        identifier: 'grant-123',
+        eventId: 'evt-1',
+        queryParams: { calendar_id: 'cal-1', notify_participants: false },
+        requestBody: {
+          participants: [
+            { email: 'a@example.test', name: 'A' },
+            { email: 'b@example.test', name: '' },
+          ],
+        },
+      });
+      const body = (sdk.events.update as ReturnType<typeof vi.fn>).mock.calls[0]![0].requestBody as {
+        participants: Array<Record<string, unknown>>;
+      };
+      for (const participant of body.participants) {
+        expect(participant).not.toHaveProperty('status');
+      }
+    });
   });
 
   describe('deleteEvent', () => {

--- a/tests/unit/skills/calendar-create-event.test.ts
+++ b/tests/unit/skills/calendar-create-event.test.ts
@@ -6,7 +6,7 @@ import pino from 'pino';
 const logger = pino({ level: 'silent' });
 
 function makeCtx(input: Record<string, unknown>, overrides?: Partial<ToolContext>): ToolContext {
-  return { toolName: 'calendar-create-event', toolVersion: '1.0.1', input, secret: () => { throw new Error('no secrets'); }, log: logger, ...overrides };
+  return { toolName: 'calendar-create-event', toolVersion: '1.1.0', input, secret: () => { throw new Error('no secrets'); }, log: logger, ...overrides };
 }
 
 describe('CalendarCreateEventHandler', () => {
@@ -84,5 +84,25 @@ describe('CalendarCreateEventHandler', () => {
       { nylasCalendarClient: nylasCalendarClient as never },
     ));
     expect(result.success).toBe(true);
+  });
+
+  it('rejects attendee RSVP status instead of sending it to createEvent', async () => {
+    const nylasCalendarClient = { createEvent: vi.fn() };
+    const result = await handler.execute(makeCtx(
+      {
+        calendarId: 'cal-1',
+        title: 'Test',
+        start: '2026-04-01T09:00:00Z',
+        end: '2026-04-01T10:00:00Z',
+        attendees: [{ email: 'a@example.test', status: 'yes' }],
+      },
+      { nylasCalendarClient: nylasCalendarClient as never },
+    ));
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toMatch(/response status cannot be set/i);
+      expect(result.error).toContain('calendar-respond-to-invite');
+    }
+    expect(nylasCalendarClient.createEvent).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/skills/calendar-update-event.test.ts
+++ b/tests/unit/skills/calendar-update-event.test.ts
@@ -155,7 +155,7 @@ describe('CalendarUpdateEventHandler', () => {
     }
   });
 
-  it('fails when the provider response omits a requested attendee', async () => {
+  it('warns when the provider response omits a requested attendee without claiming the write failed', async () => {
     const nylasCalendarClient = {
       updateEvent: vi.fn().mockResolvedValue(makeEvent({
         participants: [{ email: 'a@example.test', name: 'A', status: 'noreply' }],
@@ -172,10 +172,35 @@ describe('CalendarUpdateEventHandler', () => {
       },
       { nylasCalendarClient: nylasCalendarClient as never },
     ));
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(result.error).toMatch(/did not include/i);
-      expect(result.error).not.toMatch(/success/i);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { warnings?: string[] };
+      expect(data.warnings?.some((w) => /omitted/i.test(w) && /do not retry/i.test(w))).toBe(true);
+    }
+  });
+
+  it('warns on extra returned participants and does not throw when a participant has no email', async () => {
+    const nylasCalendarClient = {
+      updateEvent: vi.fn().mockResolvedValue(makeEvent({
+        participants: [
+          { email: 'a@example.test', name: 'A', status: 'noreply' },
+          { email: undefined as unknown as string, name: 'Room', status: 'noreply' },
+          { email: 'organizer@example.test', name: 'Org', status: 'yes' },
+        ],
+      })),
+    };
+    const result = await handler.execute(makeCtx(
+      {
+        calendarId: 'cal-1',
+        eventId: 'evt-1',
+        attendees: [{ email: 'a@example.test', name: 'A' }],
+      },
+      { nylasCalendarClient: nylasCalendarClient as never },
+    ));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { warnings?: string[] };
+      expect(data.warnings?.some((w) => /extra participant/i.test(w))).toBe(true);
     }
   });
 

--- a/tests/unit/skills/calendar-update-event.test.ts
+++ b/tests/unit/skills/calendar-update-event.test.ts
@@ -1,12 +1,33 @@
 import { describe, it, expect, vi } from 'vitest';
 import { CalendarUpdateEventHandler } from '../../../skills/calendar/tools/calendar-update-event/handler.js';
 import type { ToolContext } from '../../../src/skills/types.js';
+import type { NylasCalendarEvent } from '../../../src/channels/calendar/nylas-calendar-client.js';
 import pino from 'pino';
 
 const logger = pino({ level: 'silent' });
 
 function makeCtx(input: Record<string, unknown>, overrides?: Partial<ToolContext>): ToolContext {
-  return { toolName: 'calendar-update-event', toolVersion: '1.0.0', input, secret: () => { throw new Error('no secrets'); }, log: logger, ...overrides };
+  return { toolName: 'calendar-update-event', toolVersion: '1.1.0', input, secret: () => { throw new Error('no secrets'); }, log: logger, ...overrides };
+}
+
+function makeEvent(overrides?: Partial<NylasCalendarEvent>): NylasCalendarEvent {
+  return {
+    id: 'evt-1',
+    title: 'Updated',
+    description: '',
+    location: '',
+    startTime: 1775466000,
+    endTime: 1775469600,
+    startDate: null,
+    endDate: null,
+    participants: [],
+    conferencing: null,
+    status: 'confirmed',
+    calendarId: 'cal-1',
+    busy: true,
+    metadata: null,
+    ...overrides,
+  };
 }
 
 describe('CalendarUpdateEventHandler', () => {
@@ -43,8 +64,7 @@ describe('CalendarUpdateEventHandler', () => {
   });
 
   it('updates event successfully', async () => {
-    const updatedEvent = { id: 'evt-1', title: 'Updated', description: '', location: '', startTime: 1775466000, endTime: 1775469600, startDate: null, endDate: null, participants: [], conferencing: null, status: 'confirmed', calendarId: 'cal-1', busy: true };
-    const nylasCalendarClient = { updateEvent: vi.fn().mockResolvedValue(updatedEvent) };
+    const nylasCalendarClient = { updateEvent: vi.fn().mockResolvedValue(makeEvent()) };
     const contactService = { resolveCalendar: vi.fn().mockResolvedValue(null) };
     const result = await handler.execute(makeCtx(
       { calendarId: 'cal-1', eventId: 'evt-1', title: 'Updated' },
@@ -57,6 +77,124 @@ describe('CalendarUpdateEventHandler', () => {
       // Timestamps must be ISO strings, not raw Unix seconds
       expect(data.event.startTime).toBe('2026-04-06T09:00:00.000Z');
       expect(data.event.endTime).toBe('2026-04-06T10:00:00.000Z');
+    }
+  });
+
+  it('rejects attendee RSVP status instead of silently dropping it', async () => {
+    const nylasCalendarClient = { updateEvent: vi.fn() };
+    const result = await handler.execute(makeCtx(
+      {
+        calendarId: 'cal-1',
+        eventId: 'evt-1',
+        attendees: [
+          { email: 'a@example.test', name: 'A', status: 'yes' },
+          { email: 'b@example.test', name: 'B' },
+        ],
+      },
+      { nylasCalendarClient: nylasCalendarClient as never },
+    ));
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toMatch(/response status cannot be set/i);
+      expect(result.error).toContain('calendar-respond-to-invite');
+    }
+    expect(nylasCalendarClient.updateEvent).not.toHaveBeenCalled();
+  });
+
+  it('rejects Google-style responseStatus on an otherwise valid guest-list replace', async () => {
+    const nylasCalendarClient = { updateEvent: vi.fn() };
+    const result = await handler.execute(makeCtx(
+      {
+        calendarId: 'cal-1',
+        eventId: 'evt-1',
+        attendees: [{ email: 'a@example.test', responseStatus: 'accepted' }],
+      },
+      { nylasCalendarClient: nylasCalendarClient as never },
+    ));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toMatch(/response status cannot be set/i);
+    expect(nylasCalendarClient.updateEvent).not.toHaveBeenCalled();
+  });
+
+  it('replaces the full guest list as email and name only', async () => {
+    const nylasCalendarClient = {
+      updateEvent: vi.fn().mockResolvedValue(makeEvent({
+        participants: [
+          { email: 'a@example.test', name: 'A', status: 'noreply' },
+          { email: 'b@example.test', name: 'B', status: 'yes' },
+        ],
+      })),
+    };
+    const result = await handler.execute(makeCtx(
+      {
+        calendarId: 'cal-1',
+        eventId: 'evt-1',
+        attendees: [
+          { email: 'a@example.test', name: 'A' },
+          { email: 'b@example.test', name: 'B' },
+        ],
+      },
+      { nylasCalendarClient: nylasCalendarClient as never },
+    ));
+    expect(result.success).toBe(true);
+    expect(nylasCalendarClient.updateEvent).toHaveBeenCalledWith(
+      'cal-1',
+      'evt-1',
+      {
+        attendees: [
+          { email: 'a@example.test', name: 'A' },
+          { email: 'b@example.test', name: 'B' },
+        ],
+      },
+      undefined,
+    );
+    const attendees = nylasCalendarClient.updateEvent.mock.calls[0]![2].attendees as Array<Record<string, unknown>>;
+    expect(attendees).toHaveLength(2);
+    for (const attendee of attendees) {
+      expect(attendee).not.toHaveProperty('status');
+    }
+  });
+
+  it('fails when the provider response omits a requested attendee', async () => {
+    const nylasCalendarClient = {
+      updateEvent: vi.fn().mockResolvedValue(makeEvent({
+        participants: [{ email: 'a@example.test', name: 'A', status: 'noreply' }],
+      })),
+    };
+    const result = await handler.execute(makeCtx(
+      {
+        calendarId: 'cal-1',
+        eventId: 'evt-1',
+        attendees: [
+          { email: 'a@example.test', name: 'A' },
+          { email: 'b@example.test', name: 'B' },
+        ],
+      },
+      { nylasCalendarClient: nylasCalendarClient as never },
+    ));
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toMatch(/did not include/i);
+      expect(result.error).not.toMatch(/success/i);
+    }
+  });
+
+  it('passes notifyAttendees through and warns that Microsoft/iCloud still notify', async () => {
+    const nylasCalendarClient = { updateEvent: vi.fn().mockResolvedValue(makeEvent()) };
+    const result = await handler.execute(makeCtx(
+      { calendarId: 'cal-1', eventId: 'evt-1', title: 'Quiet update', notifyAttendees: false },
+      { nylasCalendarClient: nylasCalendarClient as never },
+    ));
+    expect(result.success).toBe(true);
+    expect(nylasCalendarClient.updateEvent).toHaveBeenCalledWith(
+      'cal-1',
+      'evt-1',
+      { title: 'Quiet update' },
+      false,
+    );
+    if (result.success) {
+      const data = result.data as { warnings?: string[] };
+      expect(data.warnings?.[0]).toMatch(/Microsoft and iCloud/i);
     }
   });
 });


### PR DESCRIPTION
## Summary

`calendar-update-event` advertised attendee management, then silently dropped RSVP status before the request left the process and reported success. The issue's original acceptance criteria asked us to send that status through to Nylas. That is not actually possible.

**Nylas rejects organizer-set participant status on PUT** (`"Updating the status for participants is not allowed, only participants can rsvp"`). The SDK's `Participant.status` field is a shared read/write type, not a write capability. Google Calendar's native API can write `attendees[].responseStatus` as organizer; Microsoft Graph cannot set another attendee's response; Nylas fails closed for both. First-person RSVP remains `calendar-respond-to-invite` (`sendRsvp`), by #1217's design.

This PR makes the tool describe and enforce what the providers actually support:

- Reject attendee `status` / `responseStatus` / `participationStatus` instead of dropping them
- Treat `attendees` as a full guest-list replace (`email` + optional `name` only)
- Fail if the provider response omits a requested attendee email
- Add `notifyAttendees` → Nylas `notify_participants`, with an explicit warning that Microsoft and iCloud ignore `false`

Closes #1735

## Changes

- `calendar-update-event` handler validates attendees, refuses RSVP-status writes, verifies the returned guest list, and forwards `notifyAttendees`
- `NylasCalendarClient.updateEvent` never puts `status` on `participants`; `notify_participants` is a query param
- Manifest drops unimplemented `colorId` / `reminders` and documents guest-list replace + Google-only notification suppression
- Calendar agent prompt: do not use update-event to record another guest's RSVP

## Related Issues

Closes #1735

## Checklist

- [x] Code follows project conventions (see CLAUDE.md)
- [x] Tests added/updated for new functionality
- [x] No `any` types introduced
- [x] No empty `catch {}` blocks
- [x] No `console.log` in backend code (use pino; `apps/` is exempt)
- [ ] Spec docs updated if behavior changes
- [ ] CI passes
